### PR TITLE
Fix Decode.oneOf in combination with object builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.0.0-beta-004 - 2019-04-02
+### Fixed
+* Fix Decode.oneOf in combination with object builder (by @alfonsogarciacaro)
+* Make `Decode.field` consistant and report the exact error
+
+### Changed
+* Make Decode.object output 1 error or all the errors if there are severals
+* Improve BadOneOf errors readibility
+
 ## 3.0.0-beta-003 - 2019-03-17
 ### Changed
 * Upgrade to `Fable.Core` v3-beta

--- a/src/Decode.fs
+++ b/src/Decode.fs
@@ -7,7 +7,6 @@ module Decode =
     open System.Globalization
     open Fable.Core
     open Fable.Core.JsInterop
-    open Fable.Import
 
     module internal Helpers =
         [<Emit("typeof $0")>]

--- a/src/Decode.fs
+++ b/src/Decode.fs
@@ -106,11 +106,25 @@ module Decode =
     // Runners ///
     /////////////
 
+    let private decodeValueError path (decoder : Decoder<'T>) =
+        fun value ->
+            try
+                match decoder path value with
+                | Ok success ->
+                    Ok success
+                | Error error ->
+                    Error error
+            with
+                | DecoderException error ->
+                    Error error
+
     let fromValue (path : string) (decoder : Decoder<'T>) =
         fun value ->
-            match decoder path value with
-            | Ok success -> Ok success
-            | Error error -> Error (errorToString error)
+            match decodeValueError path decoder value with
+            | Ok success ->
+                Ok success
+            | Error error ->
+                Error (errorToString error)
 
     let fromString (decoder : Decoder<'T>) =
         fun value ->

--- a/src/Decode.fs
+++ b/src/Decode.fs
@@ -647,10 +647,11 @@ module Decode =
             match getters.Errors with
             | [] -> Ok result
             | fst::_ as errors ->
-                // TODO: Aggregate errors as with oneOf?
-                // let errors = List.map errorToString errors
-                // (path, BadOneOf errors) |> Error
-                Error fst
+                if errors.Length > 1 then
+                    let errors = List.map errorToString errors
+                    (path, BadOneOf errors) |> Error
+                else
+                    Error fst
 
     ///////////////////////
     // Tuples decoders ///

--- a/src/Decode.fs
+++ b/src/Decode.fs
@@ -291,30 +291,29 @@ module Decode =
     // Object primitives ///
     ///////////////////////
 
-    let field (fieldName: string) (decoder : Decoder<'value>) : Decoder<'value> =
+    let optional (fieldName : string) (decoder : Decoder<'value>) : Decoder<'value option> =
         fun path value ->
             if Helpers.isObject value then
                 let fieldValue = Helpers.getField fieldName value
-                match decoder (path + "." + fieldName) fieldValue with
-                | Ok _ as ok -> ok
-                | Error _ as er ->
-                    if Helpers.isUndefined fieldValue then
-                        Error(path, BadField ("an object with a field named `" + fieldName + "`", value))
-                    else er
+                if Helpers.isUndefined fieldValue then Ok None
+                else decoder (path + "." + fieldName) fieldValue |> Result.map Some
             else
                 Error(path, BadType("an object", value))
 
-    let at (fieldNames: string list) (decoder : Decoder<'value>) : Decoder<'value> =
+    let private badPathError fieldNames currentPath value =
+        let currentPath = defaultArg currentPath ("$"::fieldNames |> String.concat ".")
+        let msg = "an object with path `" + (String.concat "." fieldNames) + "`"
+        Error(currentPath, BadPath (msg, value, List.tryLast fieldNames |> Option.defaultValue ""))
+
+    let optionalAt (fieldNames : string list) (decoder : Decoder<'value>) : Decoder<'value option> =
         fun firstPath firstValue ->
-            let pathErrorMsg () =
-                "an object with path `" + (String.concat "." fieldNames) + "`"
             ((firstPath, firstValue, None), fieldNames)
             ||> List.fold (fun (curPath, curValue, res) field ->
                 match res with
                 | Some _ -> curPath, curValue, res
                 | None ->
                     if Helpers.isNullValue curValue then
-                        let res = Error(curPath, BadPath(pathErrorMsg(), firstValue, field))
+                        let res = badPathError fieldNames (Some curPath) firstValue
                         curPath, curValue, Some res
                     elif Helpers.isObject curValue then
                         let curValue = Helpers.getField field curValue
@@ -325,12 +324,22 @@ module Decode =
             |> function
                 | _, _, Some res -> res
                 | lastPath, lastValue, None ->
-                    match decoder lastPath lastValue with
-                    | Ok _ as ok -> ok
-                    | Error _ as er ->
-                        if Helpers.isUndefined lastValue then
-                            Error(lastPath, BadPath (pathErrorMsg(), firstValue, List.tryLast fieldNames |> Option.defaultValue ""))
-                        else er
+                    if Helpers.isUndefined lastValue then Ok None
+                    else decoder lastPath lastValue |> Result.map Some
+
+    let field (fieldName: string) (decoder : Decoder<'value>) : Decoder<'value> =
+        fun path value ->
+            match optional fieldName decoder path value with
+            | Error er -> Error er
+            | Ok(Some x) -> Ok x
+            | Ok None -> Error(path, BadField ("an object with a field named `" + fieldName + "`", value))
+
+    let at (fieldNames: string list) (decoder : Decoder<'value>) : Decoder<'value> =
+        fun path value ->
+            match optionalAt fieldNames decoder path value with
+            | Error er -> Error er
+            | Ok(Some x) -> Ok x
+            | Ok None -> badPathError fieldNames None value
 
     let index (requestedIndex: int) (decoder : Decoder<'value>) : Decoder<'value> =
         fun path value ->
@@ -357,12 +366,6 @@ module Decode =
         fun path value ->
             if Helpers.isNullValue value then Ok None
             else decoder path value |> Result.map Some
-
-    let optional (fieldName : string) (decoder : Decoder<'value>) : Decoder<'value option> =
-        field fieldName (option decoder)
-
-    let optionalAt (fieldNames : string list) (decoder : Decoder<'value>) : Decoder<'value option> =
-        at fieldNames (option decoder)
 
     //////////////////////
     // Data structure ///
@@ -622,9 +625,9 @@ module Decode =
                 member __.Optional =
                     { new IOptionalGetter with
                         member __.Field (fieldName : string) (decoder : Decoder<_>) =
-                            unwrap path (field fieldName (option decoder)) v
+                            unwrap path (optional fieldName decoder) v
                         member __.At (fieldNames : string list) (decoder : Decoder<_>) =
-                            unwrap path (at fieldNames (option decoder)) v
+                            unwrap path (optionalAt fieldNames decoder) v
                         member __.Raw (decoder: Decoder<_>) =
                             match decoder path v with
                             | Ok v -> Some v
@@ -824,7 +827,8 @@ module Decode =
                 match acc with
                 | Error _ -> acc
                 | Ok result ->
-                    field name decoder path value
+                    Helpers.getField name value
+                    |> decoder (path + "." + name)
                     |> Result.map (fun v -> v::result))
 
     let private autoObject2 (keyDecoder: BoxedDecoder) (valueDecoder: BoxedDecoder) (path : string) (value: JsonValue) =
@@ -838,9 +842,11 @@ module Decode =
                     match keyDecoder path name with
                     | Error er -> Error er
                     | Ok k ->
-                        match field name valueDecoder path value with
-                        | Error er -> Error er
-                        | Ok v -> (k,v)::acc |> Ok)
+                        Helpers.getField name value
+                        |> valueDecoder (path + "." + name)
+                        |> function
+                            | Error er -> Error er
+                            | Ok v -> (k,v)::acc |> Ok)
 
     let private mixedArray msg (decoders: BoxedDecoder[]) (path: string) (values: JsonValue[]): Result<JsonValue list, DecoderError> =
         if decoders.Length <> values.Length then

--- a/src/Decode.fs
+++ b/src/Decode.fs
@@ -81,7 +81,7 @@ module Decode =
             | TooSmallArray (msg, value) ->
                 "Expecting " + msg + ".\n" + (Helpers.anyToString value)
             | BadOneOf messages ->
-                "I run into the following problems:\n\n" + String.concat "\n" messages
+                "I run into the following problems:\n\n" + String.concat "\n\n" messages
             | FailMessage msg ->
                 "I run into a `fail` decoder: " + msg
 

--- a/src/Encode.fs
+++ b/src/Encode.fs
@@ -5,9 +5,11 @@ module Encode =
 
     open System.Collections.Generic
     open System.Globalization
-    open Fable.Import
     open Fable.Core
     open Fable.Core.JsInterop
+
+    [<Emit("Array.from($0)")>]
+    let private arrayFrom(x: JsonValue seq): JsonValue = jsNative
 
     ///**Description**
     /// Encode a string
@@ -149,12 +151,12 @@ module Encode =
     ///
     ///**Exceptions**
     ///
-    let inline list (values : JsonValue list) : JsonValue =
+    let list (values : JsonValue list) : JsonValue =
         // Don't use List.toArray as it may create a typed array
-        box (JS.Array.from(box values :?> JS.Iterable<JsonValue>))
+        arrayFrom values
 
-    let inline seq (values : JsonValue seq) : JsonValue =
-        box (JS.Array.from(values :?> JS.Iterable<JsonValue>))
+    let seq (values : JsonValue seq) : JsonValue =
+        arrayFrom values
 
     ///**Description**
     /// Encode a dictionary

--- a/tests/Tests.Json.Decode.fs
+++ b/tests/Tests.Json.Decode.fs
@@ -1005,6 +1005,24 @@ Expecting an array but instead got: 1
 
                 equal expected actual
 
+            testCase "oneOf works in combination with object builders" <| fun _ ->
+                let json = """{ "Bar": { "name": "maxime", "age": 25 } }"""
+                let expected = Ok(Choice2Of2 { fieldA = "maxime" })
+
+                let decoder1 =
+                    Decode.object (fun get ->
+                        { fieldA = get.Required.Field "name" Decode.string })
+
+                let decoder2 =
+                    Decode.oneOf [
+                        Decode.field "Foo" decoder1 |> Decode.map Choice1Of2
+                        Decode.field "Bar" decoder1 |> Decode.map Choice2Of2
+                    ]
+
+                let actual =
+                    Decode.fromString decoder2 json
+
+                equal expected actual
 
             testCase "oneOf output errors if all case fails" <| fun _ ->
                 let expected =

--- a/tests/Tests.Json.Decode.fs
+++ b/tests/Tests.Json.Decode.fs
@@ -1070,6 +1070,17 @@ Expecting an object but instead got:
 
                 equal expectedUndefinedField actualUndefinedField
 
+            testCase "optional returns Error value if decoder fails" <| fun _ ->
+                let json = """{ "name": 12, "age": 25 }"""
+                let expected = Error("""
+Error at: `$.name`
+Expecting a string but instead got: 12""".Trim())
+
+                let actual =
+                    Decode.fromString (Decode.optional "name" Decode.string) json
+
+                equal expected actual
+
             testCase "optionalAt works" <| fun _ ->
                 let json = """{ "data" : { "name": "maxime", "age": 25, "something_undefined": null } }"""
 
@@ -1484,6 +1495,19 @@ Expecting a string but instead got: 12
 
                 let actual =
                     Decode.fromString decoder json
+
+                equal expected actual
+
+            testCase "get.Optional.Field returns Error value if decoder fails" <| fun _ ->
+                let json = """{ "name": 12, "age": 25 }"""
+                let expected = Error("""
+Error at: `$.name`
+Expecting a string but instead got: 12""".Trim())
+
+                let decoder = Decode.object (fun get ->
+                    { optionalField = get.Optional.Field "name" Decode.string })
+
+                let actual = Decode.fromString decoder json
 
                 equal expected actual
 

--- a/tests/Tests.Json.Decode.fs
+++ b/tests/Tests.Json.Decode.fs
@@ -1083,12 +1083,11 @@ Expecting an object but instead got:
 
                 equal expectedMissingField actualMissingField
 
-                // TODO: Should this test pass? The field is present but not a string
-                // let expectedUndefinedField = Ok(None)
-                // let actualUndefinedField =
-                //     Decode.fromString (Decode.optional "something_undefined" Decode.string) json
+                let expectedUndefinedField = Ok(None)
+                let actualUndefinedField =
+                    Decode.fromString (Decode.optional "something_undefined" Decode.string) json
 
-                // equal expectedUndefinedField actualUndefinedField
+                equal expectedUndefinedField actualUndefinedField
 
             testCase "optional returns Error value if decoder fails" <| fun _ ->
                 let json = """{ "name": 12, "age": 25 }"""
@@ -1120,12 +1119,11 @@ Expecting a string but instead got: 12""".Trim())
 
                 equal expectedMissingField actualMissingField
 
-                // TODO: Should this test pass? The field is present but not a string
-                // let expectedUndefinedField = Ok(None)
-                // let actualUndefinedField =
-                //     Decode.fromString (Decode.optionalAt [ "data"; "something_undefined" ] Decode.string) json
+                let expectedUndefinedField = Ok(None)
+                let actualUndefinedField =
+                    Decode.fromString (Decode.optionalAt [ "data"; "something_undefined" ] Decode.string) json
 
-                // equal expectedUndefinedField actualUndefinedField
+                equal expectedUndefinedField actualUndefinedField
 
             testCase "combining field and option decoders works" <| fun _ ->
                 let json = """{ "name": "maxime", "age": 25, "something_undefined": null }"""
@@ -1505,21 +1503,20 @@ Expecting a string but instead got: 12
 
                 equal expected actual
 
-            // TODO: Should this test pass? The field is present but not a string
-            // testCase "get.Optional.Field returns None if field is null" <| fun _ ->
-            //     let json = """{ "name": null, "age": 25 }"""
-            //     let expected = Ok({ optionalField = None })
+            testCase "get.Optional.Field returns None if field is null" <| fun _ ->
+                let json = """{ "name": null, "age": 25 }"""
+                let expected = Ok({ optionalField = None })
 
-            //     let decoder =
-            //         Decode.object
-            //             (fun get ->
-            //                 { optionalField = get.Optional.Field "name" Decode.string }
-            //             )
+                let decoder =
+                    Decode.object
+                        (fun get ->
+                            { optionalField = get.Optional.Field "name" Decode.string }
+                        )
 
-            //     let actual =
-            //         Decode.fromString decoder json
+                let actual =
+                    Decode.fromString decoder json
 
-            //     equal expected actual
+                equal expected actual
 
             testCase "get.Optional.Field returns Error value if decoder fails" <| fun _ ->
                 let json = """{ "name": 12, "age": 25 }"""
@@ -1534,31 +1531,30 @@ Expecting a string but instead got: 12""".Trim())
 
                 equal expected actual
 
-            // TODO: Should this test pass? The field is present but not a user
-            // testCase "nested get.Optional.Field > get.Required.Field returns None if field is null" <| fun _ ->
-            //     let json = """{ "user": null, "field2": 25 }"""
-            //     let expected = Ok({ User = None; Field2 = 25 })
+            testCase "nested get.Optional.Field > get.Required.Field returns None if field is null" <| fun _ ->
+                let json = """{ "user": null, "field2": 25 }"""
+                let expected = Ok({ User = None; Field2 = 25 })
 
-            //     let userDecoder =
-            //         Decode.object
-            //             (fun get ->
-            //                 { Id = get.Required.Field "id" Decode.int
-            //                   Name = get.Required.Field "name" Decode.string
-            //                   Email = get.Required.Field "email" Decode.string
-            //                   Followers = 0 }
-            //             )
+                let userDecoder =
+                    Decode.object
+                        (fun get ->
+                            { Id = get.Required.Field "id" Decode.int
+                              Name = get.Required.Field "name" Decode.string
+                              Email = get.Required.Field "email" Decode.string
+                              Followers = 0 }
+                        )
 
-            //     let decoder =
-            //         Decode.object
-            //             (fun get ->
-            //                 { User = get.Optional.Field "user" userDecoder
-            //                   Field2 = get.Required.Field "field2" Decode.int }
-            //             )
+                let decoder =
+                    Decode.object
+                        (fun get ->
+                            { User = get.Optional.Field "user" userDecoder
+                              Field2 = get.Required.Field "field2" Decode.int }
+                        )
 
-            //     let actual =
-            //         Decode.fromString decoder json
+                let actual =
+                    Decode.fromString decoder json
 
-            //     equal expected actual
+                equal expected actual
 
             testCase "get.Optional.Field returns Error if type is incorrect" <| fun _ ->
                 let json = """{ "name": 12, "age": 25 }"""

--- a/tests/Tests.Json.Decode.fs
+++ b/tests/Tests.Json.Decode.fs
@@ -1072,6 +1072,7 @@ I run into the following problems:
 
 Error at: `$.[0]`
 Expecting a string but instead got: 1
+
 Error at: `$.[0]`
 Expecting an object but instead got:
 1
@@ -2151,6 +2152,7 @@ Expecting an object with a field named `missing_field_1` but instead got:
         "sub_field": "not_a_boolean"
     }
 }
+
 Error at: `$.missing_field_2`
 Expecting an object with path `missing_field_2.sub_field` but instead got:
 {
@@ -2161,8 +2163,10 @@ Expecting an object with path `missing_field_2.sub_field` but instead got:
     }
 }
 Node `sub_field` is unkown.
+
 Error at: `$.fieldC`
 Expecting an int but instead got: "not_a_number"
+
 Error at: `$.fieldD.sub_field`
 Expecting a boolean but instead got: "not_a_boolean"
                         """.Trim())

--- a/tests/Tests.Json.Decode.fs
+++ b/tests/Tests.Json.Decode.fs
@@ -1091,9 +1091,12 @@ Expecting an object but instead got:
 
             testCase "optional returns Error value if decoder fails" <| fun _ ->
                 let json = """{ "name": 12, "age": 25 }"""
-                let expected = Error("""
+                let expected =
+                    Error(
+                        """
 Error at: `$.name`
-Expecting a string but instead got: 12""".Trim())
+Expecting a string but instead got: 12
+                        """.Trim())
 
                 let actual =
                     Decode.fromString (Decode.optional "name" Decode.string) json
@@ -1137,6 +1140,34 @@ Expecting a string but instead got: 12""".Trim())
                 match Decode.fromString (Decode.field "name" (Decode.option Decode.int)) json with
                 | Error _ -> ()
                 | Ok _ -> failwith "Expected type error for `name` field"
+
+                match Decode.fromString (Decode.field "this_field_do_not_exist" (Decode.option Decode.int)) json with
+                | Error _ -> ()
+                | Ok _ -> failwith "Expected type error for `name` field"
+
+                match Decode.fromString (Decode.field "something_undefined" (Decode.option Decode.int)) json with
+                | Error _ -> ()
+                | Ok result -> equal None result
+
+                // Same tests as before but we are calling `option` then `field`
+
+                let expectedValid2 = Ok(Some "maxime")
+                let actualValid2 =
+                    Decode.fromString (Decode.option (Decode.field "name" Decode.string)) json
+
+                equal expectedValid2 actualValid2
+
+                match Decode.fromString (Decode.option (Decode.field "name" Decode.int)) json with
+                | Error _ -> ()
+                | Ok _ -> failwith "Expected type error for `name` field"
+
+                match Decode.fromString (Decode.option (Decode.field "this_field_do_not_exist" Decode.int)) json with
+                | Error _ -> ()
+                | Ok _ -> failwith "Expected type error for `name` field"
+
+                match Decode.fromString (Decode.option (Decode.field "something_undefined" Decode.int)) json with
+                | Error _ -> ()
+                | Ok result -> equal None result
 
                 // TODO: Should this test pass? We should use Decode.optional instead
                 // let expectedMissingField = Ok(None)
@@ -1520,9 +1551,12 @@ Expecting a string but instead got: 12
 
             testCase "get.Optional.Field returns Error value if decoder fails" <| fun _ ->
                 let json = """{ "name": 12, "age": 25 }"""
-                let expected = Error("""
+                let expected =
+                    Error(
+                        """
 Error at: `$.name`
-Expecting a string but instead got: 12""".Trim())
+Expecting a string but instead got: 12
+                        """.Trim())
 
                 let decoder = Decode.object (fun get ->
                     { optionalField = get.Optional.Field "name" Decode.string })


### PR DESCRIPTION
In one of my past PRs I tried to remove exception raising from the library which made me also get rid of `decodeValueError`. However, `unwrap` was still being used by the object builders and it was not possible to remove it.

https://github.com/MangelMaxime/Thoth/pull/84/files#diff-fcf19738bdd635ced3cec659bd7097a9L126

When updating one of my projects, I've noticed this made `Decode.oneOf` to fail in combination with object builders. So I need to bring `decodeValueError` back again, sorry! 😅 

The same change needs to be done for the .net part. Are you planning to put it in a different repository? This can make it harder to keep the two libraries in sync.

It would be really helpful if you could push a new version with the fix 🙏 