### PR TITLE
[WIP] Add Extra.withCustomPredicate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
     "private": true,
-    "scripts": {},
+    "scripts": {
+        "pretest": "fable-splitter -c tests/splitter.config.js",
+        "test": "mocha tests/bin"
+    },
     "devDependencies": {
         "@babel/core": "^7.2.2",
         "@babel/preset-env": "^7.2.3",

--- a/src/Extra.fs
+++ b/src/Extra.fs
@@ -1,19 +1,26 @@
 [<RequireQualifiedAccess>]
 module Thoth.Json.Extra
 
-let empty: ExtraCoders = Map.empty
-
-let inline withInt64 (extra: ExtraCoders): ExtraCoders =
-    Map.add typeof<int64>.FullName (Encode.boxEncoder Encode.int64, Decode.boxDecoder Decode.int64) extra
-
-let inline withUInt64 (extra: ExtraCoders): ExtraCoders =
-    Map.add typeof<uint64>.FullName (Encode.boxEncoder Encode.uint64, Decode.boxDecoder Decode.uint64) extra
-
-let inline withDecimal (extra: ExtraCoders): ExtraCoders =
-    Map.add typeof<decimal>.FullName (Encode.boxEncoder Encode.decimal, Decode.boxDecoder Decode.decimal) extra
-
-let inline withBigInt (extra: ExtraCoders): ExtraCoders =
-    Map.add typeof<bigint>.FullName (Encode.boxEncoder Encode.bigint, Decode.boxDecoder Decode.bigint) extra
+let empty: ExtraCoders = List.empty
 
 let inline withCustom (encoder: Encoder<'Value>) (decoder: Decoder<'Value>) (extra: ExtraCoders): ExtraCoders =
-    Map.add typeof<'Value>.FullName (Encode.boxEncoder encoder, Decode.boxDecoder decoder) extra
+    (((=) typeof<'Value>.FullName), ((fun _ -> Encode.boxEncoder encoder), (fun _ -> Decode.boxDecoder decoder)))::extra
+
+let inline withInt64 (extra: ExtraCoders): ExtraCoders =
+    withCustom Encode.int64 Decode.int64 extra
+
+let inline withUInt64 (extra: ExtraCoders): ExtraCoders =
+    withCustom Encode.uint64 Decode.uint64 extra
+
+let inline withDecimal (extra: ExtraCoders): ExtraCoders =
+    withCustom Encode.decimal Decode.decimal extra
+
+let inline withBigInt (extra: ExtraCoders): ExtraCoders =
+    withCustom Encode.bigint Decode.bigint extra
+
+let inline withCustomPredicate
+                (encoderGenerator: BoxedEncoder[] -> Encoder<'Value>)
+                (decoderGenerator: BoxedDecoder[] -> Decoder<'Value>)
+                (predicate: string->bool)
+                (extra: ExtraCoders): ExtraCoders =
+    (predicate, ((encoderGenerator >> Encode.boxEncoder), (decoderGenerator >> Decode.boxDecoder)))::extra

--- a/src/Extra.fs
+++ b/src/Extra.fs
@@ -19,8 +19,8 @@ let inline withBigInt (extra: ExtraCoders): ExtraCoders =
     withCustom Encode.bigint Decode.bigint extra
 
 let inline withCustomPredicate
-                (encoderGenerator: BoxedEncoder[] -> Encoder<'Value>)
-                (decoderGenerator: BoxedDecoder[] -> Decoder<'Value>)
+                (encoderGenerator: BoxedEncoder[] -> BoxedEncoder)
+                (decoderGenerator: BoxedDecoder[] -> BoxedDecoder)
                 (predicate: string->bool)
                 (extra: ExtraCoders): ExtraCoders =
-    (predicate, ((encoderGenerator >> Encode.boxEncoder), (decoderGenerator >> Decode.boxDecoder)))::extra
+    (predicate, (encoderGenerator, decoderGenerator))::extra

--- a/src/Types.fs
+++ b/src/Types.fs
@@ -22,7 +22,7 @@ type BoxedDecoder = Decoder<obj>
 
 type BoxedEncoder = Encoder<obj>
 
-type ExtraCoders = Map<string, BoxedEncoder * BoxedDecoder>
+type ExtraCoders = List<(string -> bool) * ((BoxedEncoder[]->BoxedEncoder) * (BoxedDecoder[]->BoxedDecoder))>
 
 module internal Util =
     open System.Collections.Generic

--- a/tests/Tests.Json.Encode.fs
+++ b/tests/Tests.Json.Encode.fs
@@ -419,6 +419,21 @@ let tests : Test =
                 let actual = Encode.Auto.toString(0, value, extra=extra)
                 equal expected actual
 
+            testCase "Encode.Auto.toString works with custom predicate extra" <| fun _ ->
+                let extra =
+                    Extra.empty
+                    |> Extra.withCustomPredicate
+                        (fun encs -> encodeDictionary (Encode.unboxEncoder encs.[0]) (Encode.unboxEncoder encs.[1]))
+                        (fun decs -> decodeDictionary (Decode.unboxDecoder decs.[0]) (Decode.unboxDecoder decs.[1]))
+                        (fun typeName -> typeName.StartsWith("System.Collections.Generic.Dictionary`2"))
+
+                let expected = """[[1,"foo"],[3,"bar"]]"""
+                let value = System.Collections.Generic.Dictionary()
+                value.Add(1, "foo")
+                value.Add(3, "bar")
+                let actual = Encode.Auto.toString(0, value, extra=extra)
+                equal expected actual
+
             testCase "Encode.Auto.toString serializes maps with Guid keys as JSON objects" <| fun _ ->
                 let m = Map [Guid.NewGuid(), 1; Guid.NewGuid(), 2]
                 let json = Encode.Auto.toString(0, m)

--- a/tests/Tests.Json.Encode.fs
+++ b/tests/Tests.Json.Encode.fs
@@ -1,6 +1,10 @@
 module Tests.Encode
 
+#if FABLE_COMPILER
 open Thoth.Json
+#else
+open Thoth.Json.Net
+#endif
 open Util.Testing
 open System
 open Tests.Decode
@@ -423,8 +427,8 @@ let tests : Test =
                 let extra =
                     Extra.empty
                     |> Extra.withCustomPredicate
-                        (fun encs -> encodeDictionary (Encode.unboxEncoder encs.[0]) (Encode.unboxEncoder encs.[1]))
-                        (fun decs -> decodeDictionary (Decode.unboxDecoder decs.[0]) (Decode.unboxDecoder decs.[1]))
+                        (fun encs -> encodeDictionary (Encode.unboxEncoder encs.[0]) (Encode.unboxEncoder encs.[1]) |> Encode.boxEncoder)
+                        (fun decs -> decodeDictionary (Decode.unboxDecoder decs.[0]) (Decode.unboxDecoder decs.[1]) |> Decode.boxDecoder)
                         (fun typeName -> typeName.StartsWith("System.Collections.Generic.Dictionary`2"))
 
                 let expected = """[[1,"foo"],[3,"bar"]]"""

--- a/tests/Thoth.Tests.fsproj
+++ b/tests/Thoth.Tests.fsproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <DefineConstants>$(DefineConstants);FABLE_COMPILER</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../src/Thoth.Json.fsproj" />


### PR DESCRIPTION
**EDIT**: Please don't merge yet, I'm having issues to adapt this to Thoth.Json.Net. It may not be a feasible approach.

I wanted to make the auto coders easy to use and hide most of the machinery to generate them. However, sometimes you need to access it to serialize some generic types, like dictionaries. This PR adds `Extra.withCustomPredicate` which enables adding custom dictionary coder, for example, to be used with `Auto`. The downside is users need to deal with boxed coders for the generic arguments, not sure if there's a way to improve the API.