### PR TITLE
Auto encoding doesn't work with decimal

### DIFF
--- a/tests/Tests.Json.Decode.fs
+++ b/tests/Tests.Json.Decode.fs
@@ -2473,6 +2473,12 @@ Expecting a boolean but instead got: "not_a_boolean"
                           Must = "must value" } : TestMaybeRecord)
                 equal expected actual
 
+            testCase "Auto.fromString works with decimal" <| fun _ ->
+                let json = """[0.1,0.2]"""
+                let expected = [0.1M; 0.2M]
+                let actual = Decode.Auto.fromString json
+                equal (Ok expected) actual
+
             testCase "Auto.fromString works with maps encoded as objects" <| fun _ ->
                 let expected = Map [("oh", { a = 2.; b = 2. }); ("ah", { a = -1.5; b = 0. })]
                 let json = """{"ah":{"a":-1.5,"b":0},"oh":{"a":2,"b":2}}"""

--- a/tests/Tests.Json.Encode.fs
+++ b/tests/Tests.Json.Encode.fs
@@ -435,6 +435,12 @@ let tests : Test =
                 let x = [Baz; Bar "foo"]
                 Encode.Auto.toString(0, x, isCamelCase=true)
                 |> equal expected
+
+            testCase "Encode.Auto.toString works with decimal" <| fun _ ->
+                let expected = """[0.1,0.2]"""
+                let x = [0.1M; 0.2M]
+                Encode.Auto.toString(0, x)
+                |> equal expected
         ]
 
     ]


### PR DESCRIPTION
Something broke here. This used to work with older fable