### PR TITLE
Edit Encode.decimal comment

### DIFF
--- a/src/Encode.fs
+++ b/src/Encode.fs
@@ -71,7 +71,7 @@ module Encode =
         box value
 
     ///**Description**
-    /// Encode a Decimal. (Currently decimal gets converted to float.)
+    /// Encode a Decimal.
     ///
     ///**Parameters**
     ///  * `value` - parameter of type `decimal`


### PR DESCRIPTION
Currently decimal is converted to string to preserve precision so the comment is not valid