### PR TITLE
Port Elm's `andMap` JSON decoder to F#

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # Thoth.Json [![Build Status](https://dev.azure.com/thoth-org/Thoth.Json/_apis/build/status/thoth-org.Thoth.Json?branchName=master)](https://dev.azure.com/thoth-org/Thoth.Json/_build/latest?definitionId=1&branchName=master)
 
-| Stable | Prerelease
---- | ---
-[![NuGet Badge](https://buildstats.info/nuget/Thoth.Json)](https://www.nuget.org/packages/Thoth.Json/) | [![NuGet Badge](https://buildstats.info/nuget/Thoth.Json?includePreReleases=true)](https://www.nuget.org/packages/Thoth.Json/)
+| Stable                                                                                                 | Prerelease                                                                                                                     |
+| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| [![NuGet Badge](https://buildstats.info/nuget/Thoth.Json)](https://www.nuget.org/packages/Thoth.Json/) | [![NuGet Badge](https://buildstats.info/nuget/Thoth.Json?includePreReleases=true)](https://www.nuget.org/packages/Thoth.Json/) |
+
+## Building and Testing
+
+| Command                                              | Comment                                                         |
+| ---------------------------------------------------- | --------------------------------------------------------------- |
+| `./fake.sh build`                                    | Build and run tests. Note that this does not have a watch mode. |
+| `./fake.sh build -t WatchDocs`                       | Watch and serve documentation                                   |
+| `yarn fable-splitter -c tests/splitter.config.js -w` |                                                                 |
+| `yarn run mocha tests/bin`                           |                                                                 |

--- a/src/Decode.fs
+++ b/src/Decode.fs
@@ -669,6 +669,14 @@ module Decode =
             | _,_,_,_,_,_,Error er,_ -> Error er
             | _,_,_,_,_,_,_,Error er -> Error er
 
+    (* A direct port from Elm:
+       Can be helpful when decoding large objects incrementally.
+       See [the `andMap` docs](https://github.com/elm-community/json-extra/blob/2.0.0/docs/andMap.md)
+       for an explanation of how `andMap` works and how to use it. *)
+
+    let andMap<'a, 'b> : 'a Decoder -> ('a -> 'b) Decoder -> 'b Decoder =
+        map2 (|>)
+
     let dict (decoder : Decoder<'value>) : Decoder<Map<string, 'value>> =
         map Map.ofList (keyValuePairs decoder)
 

--- a/tests/Decoders.fs
+++ b/tests/Decoders.fs
@@ -1594,6 +1594,20 @@ Expecting an object with a field named `version` but instead got:
                     Decode.fromString decodePoint jsonRecord
 
                 equal expected actual
+            
+            testCase "andMap works" <| fun _ ->
+                let expected = Ok({ a = 1.
+                                    b = 2. } : Record2)
+
+                let decodePoint =
+                    Decode.succeed Record2.Create
+                        |> Decode.andMap (Decode.field "a" Decode.float)
+                        |> Decode.andMap (Decode.field "b" Decode.float)
+
+                let actual =
+                    Decode.fromString decodePoint jsonRecord
+                printfn "############### %A" decodePoint
+                equal expected actual
 
             testCase "map2 generate an error if invalid" <| fun _ ->
                 let expected = Error("Error at: `$.a`\nExpecting a float but instead got: \"invalid_a_field\"")
@@ -1607,7 +1621,6 @@ Expecting an object with a field named `version` but instead got:
                     Decode.fromString decodePoint jsonRecordInvalid
 
                 equal expected actual
-
         ]
 
         testList "object builder" [


### PR DESCRIPTION
### Problem

Decoding more than eight fields with `map` is not possible.

### Solution

Port Elm's `andMap` to Thoth.Json allowing e.g. 
```
Decode.succeed Record9.Create
|> Decode.andMap (Decode.field "a" Decode.float)
...
|> Decode.andMap (Decode.field "i" Decode.float)
```

Bonus: add some basic instructions to README.

Note: the test case for `andMap` currently fails. I have no idea why and probably need some help with that.
