### PR TITLE
Add custom field coders for auto serialization

### DIFF
--- a/src/Decode.fs
+++ b/src/Decode.fs
@@ -1173,7 +1173,15 @@ module Decode =
                 elif fullname = typedefof< Map<string, obj> >.FullName then
                     autoDecodeMapOrDict (fun ar -> toMap (unbox ar) |> box) extra t
                 elif fullname = typedefof< System.Collections.Generic.Dictionary<string, obj> >.FullName then
-                    autoDecodeMapOrDict (fun ar -> toDict (unbox ar) |> box) extra t
+                    autoDecodeMapOrDict (fun ar ->
+                        // For generic keys, Fable creates a structure with a custom equality comparer.
+                        // Deal with string keys separately to let Fable generate native JS Maps
+                        if t.GenericTypeArguments.[0].FullName = typeof<string>.FullName then
+                            let dic = System.Collections.Generic.Dictionary<string, obj>()
+                            for (k, v) in (unbox ar) do dic.Add(k, v)
+                            box dic
+                        else
+                            toDict (unbox ar) |> box) extra t
                 elif fullname = typedefof< Set<string> >.FullName then
                     autoDecodeSetOrHashset (fun ar -> toSet (unbox ar) |> box) extra t
                 elif fullname = typedefof< System.Collections.Generic.HashSet<string> >.FullName then

--- a/src/Decode.fs
+++ b/src/Decode.fs
@@ -994,9 +994,9 @@ module Decode =
                     match Map.tryFind name fieldDecoders with
                     | None -> decoder path value
                     | Some fieldDecoder ->
-                        match fieldDecoder (Option.ofObj value) with
+                        match fieldDecoder path (Option.ofObj value) with
                         | UseOk v -> Ok v
-                        | UseError e -> Error(path, FailMessage e)
+                        | UseError e -> Error e
                         | UseAutoDecoder -> decoder path value
                     |> Result.map (fun v -> v::result))
 

--- a/src/Encode.fs
+++ b/src/Encode.fs
@@ -379,7 +379,7 @@ module Encode =
 
     type private EncodeAutoExtra =
         { Encoders: Map<string, ref<BoxedEncoder>>
-          FieldEncoders: Map<string, Map<string, BoxedFieldEncoder>>
+          FieldEncoders: Map<string, Map<string, FieldEncoder>>
           CaseStrategy: CaseStrategy }
 
     // As generics are erased by Fable, let's just do an unsafe cast for performance
@@ -481,7 +481,7 @@ module Encode =
             else
                 failwithf
                     """Cannot generate auto encoder for %s.
-Thoth.Json.Net only support the folluwing enum types:
+Thoth.Json.Net only support the following enum types:
 - sbyte
 - byte
 - int16

--- a/src/Extra.fs
+++ b/src/Extra.fs
@@ -5,7 +5,8 @@ open Fable.Core
 
 let empty: ExtraCoders =
     { Hash = ""
-      Coders = Map.empty }
+      Coders = Map.empty
+      DefaultFields = Map.empty }
 
 let inline internal withCustomAndKey (encoder: Encoder<'Value>) (decoder: Decoder<'Value>)
            (extra: ExtraCoders): ExtraCoders =
@@ -27,3 +28,14 @@ let inline withDecimal (extra: ExtraCoders): ExtraCoders =
 
 let inline withBigInt (extra: ExtraCoders): ExtraCoders =
     withCustomAndKey Encode.bigint Decode.bigint extra
+
+let __withDefaultFieldAndKey typeName fieldName (defaultValue: obj) (extra: ExtraCoders) =
+    { extra with Hash = System.Guid.NewGuid().ToString()
+                 DefaultFields =
+                    Map.tryFind typeName extra.DefaultFields
+                    |> Option.defaultValue Map.empty
+                    |> Map.add fieldName defaultValue
+                    |> fun m -> Map.add typeName m extra.DefaultFields }
+
+let inline withDefaultField<'T> (fieldName: string) (defaultValue: obj) (extra: ExtraCoders) =
+    __withDefaultFieldAndKey typeof<'T>.FullName fieldName defaultValue extra

--- a/src/Extra.fs
+++ b/src/Extra.fs
@@ -1,8 +1,6 @@
 [<RequireQualifiedAccess>]
 module Thoth.Json.Extra
 
-open Fable.Core
-
 let empty: ExtraCoders =
     { Hash = ""
       Coders = Map.empty
@@ -41,23 +39,14 @@ let __withCustomFieldDecoderAndKey typeFullName (fieldName: string) (fieldDecode
 let inline withCustomFieldDecoder<'T> (fieldName: string) (fieldDecoder: FieldDecoder) (extra: ExtraCoders) =
     __withCustomFieldDecoderAndKey typeof<'T>.FullName fieldName fieldDecoder extra
 
-let __withCustomFieldEncoderAndKey typeFullName (fieldName: string) (fieldEncoder: FieldEncoder<'T>) (extra: ExtraCoders) =
+let __withCustomFieldEncoderAndKey typeFullName (fieldName: string) (fieldEncoder: FieldEncoder) (extra: ExtraCoders) =
     { extra with Hash = System.Guid.NewGuid().ToString()
                  FieldEncoders =
                     Map.tryFind typeFullName extra.FieldEncoders
                     |> Option.defaultValue Map.empty
-                    |> Map.add fieldName (fun x -> x :?> 'T |> fieldEncoder)
+                    |> Map.add fieldName fieldEncoder
                     |> fun m -> Map.add typeFullName m extra.FieldEncoders }
 
-let inline withCustomFieldEncoder<'T> (fieldName: string) (fieldEncoder: FieldEncoder<'T>) (extra: ExtraCoders) =
+let inline withCustomFieldEncoder<'T> (fieldName: string) (fieldEncoder: FieldEncoder) (extra: ExtraCoders) =
     __withCustomFieldEncoderAndKey typeof<'T>.FullName fieldName fieldEncoder extra
 
-module Test =
-    open Fable.Core.Experimental
-
-    type Foo = { Foo: int }
-    let extra =
-        empty
-        |> withCustomFieldDecoder<Foo>
-            (nameofLambda(fun (x: Foo) -> x.Foo))
-            (function Some _ -> UseAutoDecoder | None -> UseOk 10)

--- a/src/Types.fs
+++ b/src/Types.fs
@@ -28,10 +28,26 @@ type BoxedDecoder = Decoder<obj>
 
 type BoxedEncoder = Encoder<obj>
 
+type FieldDecoderResult =
+    | UseOk of obj
+    | UseError of string
+    | UseAutoDecoder
+
+type FieldDecoder = JsonValue option -> FieldDecoderResult
+
+type FieldEncoderResult =
+    | UseJsonValue of JsonValue
+    | IgnoreField
+    | UseAutoEncoder
+
+type FieldEncoder<'T> = 'T -> FieldEncoderResult
+type BoxedFieldEncoder = obj -> FieldEncoderResult
+
 type ExtraCoders =
     { Hash: string
       Coders: Map<string, BoxedEncoder * BoxedDecoder>
-      DefaultFields: Map<string, Map<string, obj>> }
+      FieldDecoders: Map<string, Map<string, FieldDecoder>>
+      FieldEncoders: Map<string, Map<string, BoxedFieldEncoder>> }
 
 module internal Util =
     open System.Collections.Generic

--- a/src/Types.fs
+++ b/src/Types.fs
@@ -30,24 +30,23 @@ type BoxedEncoder = Encoder<obj>
 
 type FieldDecoderResult =
     | UseOk of obj
-    | UseError of string
+    | UseError of DecoderError
     | UseAutoDecoder
 
-type FieldDecoder = JsonValue option -> FieldDecoderResult
+type FieldDecoder = string -> JsonValue option -> FieldDecoderResult
 
 type FieldEncoderResult =
     | UseJsonValue of JsonValue
     | IgnoreField
     | UseAutoEncoder
 
-type FieldEncoder<'T> = 'T -> FieldEncoderResult
-type BoxedFieldEncoder = obj -> FieldEncoderResult
+type FieldEncoder = obj -> FieldEncoderResult
 
 type ExtraCoders =
     { Hash: string
       Coders: Map<string, BoxedEncoder * BoxedDecoder>
       FieldDecoders: Map<string, Map<string, FieldDecoder>>
-      FieldEncoders: Map<string, Map<string, BoxedFieldEncoder>> }
+      FieldEncoders: Map<string, Map<string, FieldEncoder>> }
 
 module internal Util =
     open System.Collections.Generic

--- a/src/Types.fs
+++ b/src/Types.fs
@@ -30,7 +30,8 @@ type BoxedEncoder = Encoder<obj>
 
 type ExtraCoders =
     { Hash: string
-      Coders: Map<string, BoxedEncoder * BoxedDecoder> }
+      Coders: Map<string, BoxedEncoder * BoxedDecoder>
+      DefaultFields: Map<string, Map<string, obj>> }
 
 module internal Util =
     open System.Collections.Generic
@@ -64,6 +65,6 @@ module internal Util =
         let lowerFirst (str : string) = str.[..0].ToLowerInvariant() + str.[1..]
         let convert caseStrategy fieldName =
             match caseStrategy with
-            | CamelCase -> lowerFirst fieldName 
+            | CamelCase -> lowerFirst fieldName
             | SnakeCase -> Regex.Replace(lowerFirst fieldName, "[A-Z]","_$0").ToLowerInvariant()
-            | PascalCase -> fieldName 
+            | PascalCase -> fieldName

--- a/tests/Decoders.fs
+++ b/tests/Decoders.fs
@@ -924,7 +924,7 @@ Expecting an object with path `user.firstname` but instead got:
         "age": 25
     }
 }
-Node `firstname` is unkown.
+Node `firstname` is unknown.
                         """.Trim())
 
                 let actual =
@@ -1827,7 +1827,7 @@ Expecting an object with path `user.firstname` but instead got:
         "age": 25
     }
 }
-Node `firstname` is unkown.
+Node `firstname` is unknown.
                         """.Trim())
 
                 let decoder =
@@ -2244,7 +2244,7 @@ Expecting an object with path `missing_field_2.sub_field` but instead got:
         "sub_field": "not_a_boolean"
     }
 }
-Node `sub_field` is unkown.
+Node `sub_field` is unknown.
 
 Error at: `$.fieldC`
 Expecting an int but instead got: "not_a_number"
@@ -2490,7 +2490,7 @@ Expecting a boolean but instead got: "not_a_boolean"
                         """
 Error at: `$`
 Expecting Tests.Types.Enum_Int8[System.SByte] but instead got: 2
-Reason: Unkown value provided for the enum
+Reason: Unknown value provided for the enum
                         """.Trim())
 #else
                 let value =
@@ -2498,7 +2498,7 @@ Reason: Unkown value provided for the enum
                         """
 Error at: `$`
 Expecting Tests.Types+Enum_Int8 but instead got: 2
-Reason: Unkown value provided for the enum
+Reason: Unknown value provided for the enum
                         """.Trim())
 #endif
 
@@ -2516,7 +2516,7 @@ Reason: Unkown value provided for the enum
                         """
 Error at: `$`
 Expecting Tests.Types.Enum_UInt8[System.Byte] but instead got: 2
-Reason: Unkown value provided for the enum
+Reason: Unknown value provided for the enum
                         """.Trim())
 #else
                 let value =
@@ -2524,7 +2524,7 @@ Reason: Unkown value provided for the enum
                         """
 Error at: `$`
 Expecting Tests.Types+Enum_UInt8 but instead got: 2
-Reason: Unkown value provided for the enum
+Reason: Unknown value provided for the enum
                         """.Trim())
 #endif
 
@@ -2542,7 +2542,7 @@ Reason: Unkown value provided for the enum
                         """
 Error at: `$`
 Expecting Tests.Types.Enum_Int16[System.Int16] but instead got: 2
-Reason: Unkown value provided for the enum
+Reason: Unknown value provided for the enum
                         """.Trim())
 #else
                 let value =
@@ -2550,7 +2550,7 @@ Reason: Unkown value provided for the enum
                         """
 Error at: `$`
 Expecting Tests.Types+Enum_Int16 but instead got: 2
-Reason: Unkown value provided for the enum
+Reason: Unknown value provided for the enum
                         """.Trim())
 #endif
 
@@ -2568,7 +2568,7 @@ Reason: Unkown value provided for the enum
                         """
 Error at: `$`
 Expecting Tests.Types.Enum_UInt16[System.UInt16] but instead got: 2
-Reason: Unkown value provided for the enum
+Reason: Unknown value provided for the enum
                         """.Trim())
 #else
                 let value =
@@ -2576,7 +2576,7 @@ Reason: Unkown value provided for the enum
                         """
 Error at: `$`
 Expecting Tests.Types+Enum_UInt16 but instead got: 2
-Reason: Unkown value provided for the enum
+Reason: Unknown value provided for the enum
                         """.Trim())
 #endif
 
@@ -2594,7 +2594,7 @@ Reason: Unkown value provided for the enum
                         """
 Error at: `$`
 Expecting Tests.Types.Enum_Int[System.Int32] but instead got: 4
-Reason: Unkown value provided for the enum
+Reason: Unknown value provided for the enum
                         """.Trim())
 #else
                 let value =
@@ -2602,7 +2602,7 @@ Reason: Unkown value provided for the enum
                         """
 Error at: `$`
 Expecting Tests.Types+Enum_Int but instead got: 4
-Reason: Unkown value provided for the enum
+Reason: Unknown value provided for the enum
                         """.Trim())
 #endif
 
@@ -2620,7 +2620,7 @@ Reason: Unkown value provided for the enum
                         """
 Error at: `$`
 Expecting Tests.Types.Enum_UInt32[System.UInt32] but instead got: 2
-Reason: Unkown value provided for the enum
+Reason: Unknown value provided for the enum
                         """.Trim())
 #else
                 let value =
@@ -2628,7 +2628,7 @@ Reason: Unkown value provided for the enum
                         """
 Error at: `$`
 Expecting Tests.Types+Enum_UInt32 but instead got: 2
-Reason: Unkown value provided for the enum
+Reason: Unknown value provided for the enum
                         """.Trim())
 #endif
 
@@ -2754,6 +2754,32 @@ Reason: Unkown value provided for the enum
                 let json = """[[{"a":-1.5,"b":0},"ah"],[{"a":2,"b":2},"oh"]]"""
                 let actual = Decode.Auto.fromString json
                 equal (Ok expected) actual
+
+            testCase "Auto.fromString works with mutable dictionaries" <| fun _ ->
+                let expected = System.Collections.Generic.Dictionary()
+                expected.Add("oh", { a = 2.; b = 2. })
+                expected.Add("ah", { a = -1.5; b = 0. })
+                let json = """{"ah":{"a":-1.5,"b":0},"oh":{"a":2,"b":2}}"""
+                let actual: System.Collections.Generic.Dictionary<_,_> =
+                    Decode.Auto.unsafeFromString json
+                for (KeyValue(k, v)) in expected do
+                    equal v actual.[k]
+                equal -1.5 actual.["ah"].a
+                actual.["ah"] <- { a = 0.; b = 0. }
+                equal 0. actual.["ah"].a
+
+            testCase "Auto.fromString works with mutable hashsets" <| fun _ ->
+                let expected = System.Collections.Generic.HashSet()
+                expected.Add({ a = 2.; b = 2. }) |> ignore
+                expected.Add({ a = -1.5; b = 0. }) |> ignore
+                let json = """[{"a":2,"b":2},{"a":-1.5,"b":0}]"""
+                let actual: System.Collections.Generic.HashSet<_> = Decode.Auto.unsafeFromString json
+                for x in expected do
+                    actual.Contains(x) |> equal true
+                actual.Add({ a = 3.; b = 3. }) |> ignore
+                equal 3 actual.Count
+                actual.Add({ a = 2.; b = 2. }) |> ignore
+                equal 3 actual.Count
 
             testCase "Decoder.Auto.toString works with bigint extra" <| fun _ ->
                 let extra = Extra.empty |> Extra.withBigInt

--- a/tests/Encoders.fs
+++ b/tests/Encoders.fs
@@ -533,6 +533,21 @@ let tests : Test =
                 let json = Encode.Auto.toString(0, m)
                 json.[0] = '{' |> equal true
 
+            testCase "Encode.Auto.toString serializes mutable dictionaries" <| fun _ ->
+                let d = System.Collections.Generic.Dictionary()
+                d.Add("Foo", 1)
+                d.Add("Bar", 2)
+                Encode.Auto.toString(0, d)
+                |> equal """{"Foo":1,"Bar":2}"""
+
+            testCase "Encode.Auto.toString serializes mutable hashsets" <| fun _ ->
+                let s = System.Collections.Generic.HashSet()
+                s.Add(1) |> ignore
+                s.Add(1) |> ignore
+                s.Add(2) |> ignore
+                Encode.Auto.toString(0, s)
+                |> equal """[1,2]"""
+
             testCase "Encode.Auto.toString works with records with private constructors" <| fun _ ->
                 let expected = """{"foo1":5,"foo2":7.8}"""
                 let x = { Foo1 = 5; Foo2 = 7.8 }: RecordWithPrivateConstructor


### PR DESCRIPTION
**UPDATE**: The PR has been repurposed, please see the [comment below](https://github.com/thoth-org/Thoth.Json/pull/63#issuecomment-616717880).

This is a proposal to add default values for fields in auto decoded records.

In my current project we're using a NoSql database and we're using auto coders when reading/writing and exchanging data with the frontend. However it often happens that we need to add an extra field to some documents and migrating the db is a bit cumbersome, the only thing we need is using a default value whenever we read the document from the db and write it back. When adding the field to the record type, Thoth fails deserialization if it doesn't find the field in the json. There are two solutions for this:

- Make the field optional, but this forces us to always handle the None case, even if the field is supposed to be required from now on.
- Use a manual decoder. This is what we've been doing but it's adding a lot of boilerplate to the code because we have some documents with many fields, and whenever we want to add a new one, we need to write a full manual decoder (and encoder, even if we don't need it) and we could make mistakes when doing it.

With this PR, we only need to do something like this:

```fsharp
open Fable.Core.Experimental

let extraCoders =
    Extra.empty
    |> Extra.withInt64    
    |> Extra.withDefaultField<FileRequestDTO>
        (nameofLambda(fun x -> x.OrganizationalType)) FileRequestDTO.DefaultOrganization
```

I've made the modification for my project and it's working fine, but I had to duplicate a lot of code from Thoth.Json because most of the methods used for Auto decoding are private. So it'd be great to merge the change into the library. The PR is incomplete as it doesn't include tests, nor the .NET version. If the approach is acceptable and there's a desire to merge it, I will complete it.