### PR TITLE
Auto code seq

### DIFF
--- a/src/Decode.fs
+++ b/src/Decode.fs
@@ -432,43 +432,7 @@ module Decode =
     // Data structure ///
     ////////////////////
 
-    let list (decoder : Decoder<'value>) : Decoder<'value list> =
-        fun path value ->
-            if Helpers.isArray value then
-                let mutable i = -1
-                let tokens = Helpers.asArray value
-                (Ok [], tokens) ||> Array.fold (fun acc value ->
-                    i <- i + 1
-                    match acc with
-                    | Error _ -> acc
-                    | Ok acc ->
-                        match decoder (path + ".[" + (i.ToString()) + "]") value with
-                        | Error er -> Error er
-                        | Ok value -> Ok (value::acc))
-                |> Result.map List.rev
-            else
-                (path, BadPrimitive ("a list", value))
-                |> Error
-
-    let seq (decoder : Decoder<'value>) : Decoder<'value seq> =
-        fun path value ->
-            if Helpers.isArray value then
-                let mutable i = -1
-                let tokens = Helpers.asArray value
-                (Ok (seq []), tokens) ||> Array.fold (fun acc value ->
-                    i <- i + 1
-                    match acc with
-                    | Error _ -> acc
-                    | Ok acc ->
-                        match decoder (path + ".[" + (i.ToString()) + "]") value with
-                        | Error er -> Error er
-                        | Ok value -> Ok (Seq.append [value] acc))
-                |> Result.map Seq.rev
-            else
-                (path, BadPrimitive ("a seq", value))
-                |> Error
-
-    let array (decoder : Decoder<'value>) : Decoder<'value array> =
+    let private arrayWith expectedMsg (mapping: 'value[] -> 'result) (decoder : Decoder<'value>) : Decoder<'result> =
         fun path value ->
             if Helpers.isArray value then
                 let mutable i = -1
@@ -482,9 +446,19 @@ module Decode =
                         match decoder (path + ".[" + (i.ToString()) + "]") value with
                         | Error er -> Error er
                         | Ok value -> acc.[i] <- value; Ok acc)
+                |> Result.map mapping
             else
-                (path, BadPrimitive ("an array", value))
+                (path, BadPrimitive (expectedMsg, value))
                 |> Error
+
+    let list (decoder : Decoder<'value>) : Decoder<'value list> =
+        arrayWith "a list" List.ofArray decoder
+
+    let seq (decoder : Decoder<'value>) : Decoder<'value seq> =
+        arrayWith "a seq" Seq.ofArray decoder
+
+    let array (decoder : Decoder<'value>) : Decoder<'value array> =
+        arrayWith "an array" id decoder
 
     let keyValuePairs (decoder : Decoder<'value>) : Decoder<(string * 'value) list> =
         fun path value ->
@@ -1169,9 +1143,8 @@ module Decode =
                     t.GenericTypeArguments.[0] |> (autoDecoder extra true) |> option |> boxDecoder
                 elif fullname = typedefof<obj list>.FullName then
                     t.GenericTypeArguments.[0] |> (autoDecoder extra false) |> list |> boxDecoder
-                // Disable seq support because I don't know how to implement it on Thoth.Json.Net side
-                // elif fullname = typedefof<obj seq>.FullName then
-                //     t.GenericTypeArguments.[0] |> (autoDecoder extra false) |> seq |> boxDecoder
+                elif fullname = typedefof<obj seq>.FullName then
+                    t.GenericTypeArguments.[0] |> (autoDecoder extra false) |> seq |> boxDecoder
                 elif fullname = typedefof< Map<string, obj> >.FullName then
                     autoDecodeMapOrDict (fun ar -> toMap (unbox ar) |> box) extra t
                 elif fullname = typedefof< System.Collections.Generic.Dictionary<string, obj> >.FullName then

--- a/src/Encode.fs
+++ b/src/Encode.fs
@@ -512,9 +512,8 @@ If you can't use one of these types, please pass an extra encoder.
                         else encoder.Value value)
                 elif fullname = typedefof<obj list>.FullName
                     || fullname = typedefof<Set<string>>.FullName
-                    || fullname = typedefof<HashSet<string>>.FullName then
-                    // Disable seq support for now because I don't know how to implements to on Thoth.Json.Net
-                    // || fullname = typedefof<obj seq>.FullName then
+                    || fullname = typedefof<HashSet<string>>.FullName
+                    || fullname = typedefof<obj seq>.FullName then
                     let encoder = t.GenericTypeArguments.[0] |> autoEncoder extra skipNullField
                     fun (value: obj) ->
                         value :?> obj seq |> Seq.map encoder |> seq

--- a/tests/Decoders.fs
+++ b/tests/Decoders.fs
@@ -2461,6 +2461,14 @@ Expecting a boolean but instead got: "not_a_boolean"
                 let res = Decode.Auto.unsafeFromString<int array>(json)
                 equal value res
 
+            testCase "Auto decoders works for seq" <| fun _ ->
+                let value = [1; 2; 3; 4]
+                let json = Encode.Auto.toString(4, value)
+                let res = Decode.Auto.unsafeFromString<int seq>(json)
+                // Comparing directly against a seq won't work, because
+                // res is actually an array in disguise
+                equal value (List.ofSeq res)
+
             testCase "Auto decoders works for option None" <| fun _ ->
                 let value = None
                 let json = Encode.Auto.toString(4, value)

--- a/tests/Encoders.fs
+++ b/tests/Encoders.fs
@@ -504,6 +504,12 @@ let tests : Test =
                 equal expected actual2
                 equal actual1 actual2
 
+            testCase "Encode.Auto.toString works with seq" <| fun _ ->
+                let value = seq { yield 1; yield 2 }
+                let expected = """[1,2]"""
+                let actual = Encode.Auto.toString(0, value, skipNullField = false)
+                equal expected actual
+
             testCase "Encode.Auto.toString emit null field if setted for" <| fun _ ->
                 let value = { fieldA = null }
                 let expected = """{"fieldA":null}"""


### PR DESCRIPTION
@MangelMaxime At the end it was not so difficult to implement auto coding support for seq, so here it is :) For Thoth.Json.Net I just added some commits to my last PR as it's not merged yet.

The decoded seq is just an array in disguise but this should just work, and making it a truly lazy seq would be much more difficult. It's not the case either in the manual `seq` decoder.

I've also tried to simplify the code of the manual list/seq/array decoders.