### PR TITLE
Add `keys` and `all` decoders

### DIFF
--- a/tests/Decoders.fs
+++ b/tests/Decoders.fs
@@ -1042,6 +1042,14 @@ Expecting an array but instead got: 1
 
                 equal expected actual
 
+            testCase "keys works" <| fun _ ->
+                let expected = Ok(["a"; "b"; "c"])
+
+                let actual =
+                    Decode.fromString Decode.keys """{ "a": 1, "b": 2, "c": 3 }"""
+
+                equal expected actual
+
             testCase "keyValuePairs works" <| fun _ ->
                 let expected = Ok([("a", 1) ; ("b", 2) ; ("c", 3)])
 
@@ -1442,6 +1450,44 @@ Expecting an object with a field named `version` but instead got:
 
                 equal expected actual
 
+
+            testCase "all works" <| fun _ ->
+                let expected = Ok [1; 2; 3]
+
+                let decodeAll = Decode.all [
+                    Decode.succeed 1
+                    Decode.succeed 2
+                    Decode.succeed 3
+                ]
+
+                let actual = Decode.fromString decodeAll "{}"
+
+                equal expected actual
+
+
+            testCase "all succeeds on empty lists" <| fun _ ->
+                let expected = Ok []
+
+                let decodeNone = Decode.all []
+
+                let actual = Decode.fromString decodeNone "{}"
+
+                equal expected actual
+
+
+            testCase "all fails when one decoder fails" <| fun _ ->
+                let msg = "Failed"
+                let expected = Error("Error at: `$`\nThe following `failure` occurred with the decoder: " + msg)
+
+                let decodeAll = Decode.all [
+                    Decode.succeed 1
+                    Decode.fail msg
+                    Decode.succeed 3
+                ]
+
+                let actual = Decode.fromString decodeAll "{}"
+
+                equal expected actual
         ]
 
         testList "Mapping" [

--- a/tests/Decoders.fs
+++ b/tests/Decoders.fs
@@ -1050,6 +1050,14 @@ Expecting an array but instead got: 1
 
                 equal expected actual
 
+            testCase "keys returns an error for invalid objects" <| fun _ ->
+                let expected = Error("Error at: `$`\nExpecting an object but instead got: 1")
+
+                let actual =
+                    Decode.fromString Decode.keys "1"
+
+                equal expected actual
+
             testCase "keyValuePairs works" <| fun _ ->
                 let expected = Ok([("a", 1) ; ("b", 2) ; ("c", 3)])
 
@@ -1476,12 +1484,11 @@ Expecting an object with a field named `version` but instead got:
 
 
             testCase "all fails when one decoder fails" <| fun _ ->
-                let msg = "Failed"
-                let expected = Error("Error at: `$`\nThe following `failure` occurred with the decoder: " + msg)
+                let expected = Error("Error at: `$`\nExpecting an int but instead got: {}")
 
                 let decodeAll = Decode.all [
                     Decode.succeed 1
-                    Decode.fail msg
+                    Decode.int
                     Decode.succeed 3
                 ]
 


### PR DESCRIPTION
This pull request adds two utility decoders:

> **keys**
> val keys : Decoder\<string list>

Decodes the keys of a object into a list of strings.

> **all**
> val all : decoders:Decoder<'a> list -> Decoder<'a list>

Decodes a list of decoders into a list. Fails when one of the decoders fail.

## When would these decoders be useful?
Consider an object structure like this:
```javascript
var obj = {
  special_property: {},  // type A
  id_02672: {},          // type B
  id_03091: {},          // type B
  // ...
  id_10491: {},          // type B
};
```
This structure can be parsed using `oneOf`. However, I already know which type each property is supposed to have, so using `oneOf` doesn't feel quite right here.

With these two decoders one could do:
```f#
let decodeA = (* ... *)
let decodeB = (* ... *)

let decodeSpecialProperty = 
    Decode.field "special_property" decodeA

let decodeOtherProperties = 
    Decode.keys
    |> Decode.andThen (fun keys ->
        keys
        |> List.except ["special_property"]
        |> List.map (fun key -> Decode.field key decodeB)
        |> Decode.all)
```

