### PR TITLE
Add `decoder` computation expression

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -180,6 +180,36 @@ type User =
 val it : Result<User, string> = Ok { Id = 67; Name = ""; Email = "user@mail.com"; Followers = 0 }
 ```
 
+### Computation expressions
+
+The `decoder` computation expression can be used when decoding complex JSON structures.
+
+```fsharp
+open Thoth.Json
+open Thoth.Json.Builder
+
+type FunctionCall =
+    { Name: string
+      Args: float list }
+
+    static member Decoder: Decoder<FunctionCall> =
+        decoder {
+            let! name = Decode.index 0 Decode.string
+            let! numberOfArgs = Decode.index 1 Decode.int
+            let! args =
+                [ 2 .. numberOfArgs + 1 ]
+                |> List.map (fun idx -> Decode.index idx Decode.float)
+                |> Decode.all
+
+            return { Name = name
+                     Args = args }
+        }
+
+> Decode.fromString FunctionCall.Decoder """["square", 3, 1.23, 2, 42]"""
+val it : Result<FunctionCall, string> = Ok { Name = "square"; Args = [1.23; 2; 42] }
+```
+
+
 ## Encoder
 
 Module for turning F# values into JSON values.

--- a/src/Builder.fs
+++ b/src/Builder.fs
@@ -1,0 +1,12 @@
+﻿module Thoth.Json.Builder
+
+type DecoderBuilder() =
+    member __.Bind(decoder: 'a Decoder, f: 'a -> 'b Decoder): 'b Decoder = Decode.andThen f decoder
+
+    member __.Return(value: 'a): 'a Decoder = Decode.succeed value
+
+    member __.ReturnFrom(decoder: 'a Decoder): 'a Decoder = decoder
+
+    member __.Zero(): unit Decoder = __.Return()
+
+let decoder = DecoderBuilder()

--- a/src/Thoth.Json.fsproj
+++ b/src/Thoth.Json.fsproj
@@ -22,6 +22,7 @@ If you are interested on using it against .NET Core or .NET Framework, please us
     <Compile Include="Decode.fs" />
     <Compile Include="Encode.fs" />
     <Compile Include="Extra.fs" />
+    <Compile Include="Builder.fs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="*.fsproj; **\*.fs; **\*.js" PackagePath="fable" />

--- a/tests/Builder.fs
+++ b/tests/Builder.fs
@@ -1,0 +1,93 @@
+﻿module Tests.Builder
+
+open Thoth.Json
+open Thoth.Json.Builder
+open Util.Testing
+
+let tests: Test =
+    testList "Thoth.Json.Builder" [
+        testList "Basic Tests" [
+            testCase "return works" <| fun _ ->
+                let expected = Ok 42
+
+                let decodeFortyTwo =
+                    decoder { return 42 }
+
+                let actual = Decode.fromString decodeFortyTwo "{}"
+
+                equal expected actual
+
+
+            testCase "return! works" <| fun _ ->
+                let expected = Ok 42
+
+                let decodeInt =
+                    decoder { return! Decode.int }
+
+                let actual = Decode.fromString decodeInt "42"
+
+                equal expected actual
+
+
+            testCase "let! works" <| fun _ ->
+                let expected = Ok 42
+
+                let decodeIntPlusOne =
+                    decoder {
+                        let! value = Decode.int
+                        return value + 1 }
+
+                let actual = Decode.fromString decodeIntPlusOne "41"
+
+                equal expected actual
+
+
+            testCase "zero works" <| fun _ ->
+                let expected = Ok ()
+
+                let validateFortyTwo =
+                    decoder {
+                        let! value = Decode.int
+                        if value <> 42 then return! Decode.fail "Not 42!"
+                    }
+
+                let actual = Decode.fromString validateFortyTwo "42"
+
+                equal expected actual
+
+
+            testCase "multiple let! statements work" <| fun _ ->
+                let expected = Ok (42, "EUR")
+
+                let decodeMoney =
+                    decoder {
+                        let! value = Decode.int |> Decode.field "value"
+                        let! currency = Decode.string |> Decode.field "currency"
+                        return value, currency
+                    }
+
+                let actual = Decode.fromString decodeMoney """{ "value": 42, "currency": "EUR" }"""
+
+                equal expected actual
+
+
+            testCase "returns an error on invalid json" <| fun _ ->
+                let expected =
+                    Error(
+                        """
+Error at: `$.value`
+Expecting an int but instead got: "forty two"
+                        """.Trim())
+
+                let decodeMoney =
+                    decoder {
+                        let! value = Decode.int |> Decode.field "value"
+                        let! currency = Decode.string |> Decode.field "currency"
+                        return value, currency
+                    }
+
+                let actual = Decode.fromString decodeMoney """{ "value": "forty two", "currency": "EUR" }"""
+
+                equal expected actual
+        ]
+    ]

--- a/tests/Main.fs
+++ b/tests/Main.fs
@@ -9,6 +9,7 @@ let run () =
     let tests = [ Tests.Decoders.tests
                   Tests.Encoders.tests
                   Tests.ExtraCoders.tests
+                  Tests.Builder.tests
                 ] :> Util.Testing.Test seq
 
     for (moduleName, moduleTests) in tests do

--- a/tests/Thoth.Tests.fsproj
+++ b/tests/Thoth.Tests.fsproj
@@ -11,6 +11,7 @@
     <Compile Include="Decoders.fs" />
     <Compile Include="Encoders.fs" />
     <Compile Include="ExtraCoders.fs" />
+    <Compile Include="Builder.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
   <Import Project="..\.paket\Paket.Restore.targets" />


### PR DESCRIPTION
This pull request adds the `decoder` computation expression.
Use cases:
- decoding tuples which have more than 8 elements
- decoding complex JSON structures

Example:
```f#
open Thoth.Json
open Thoth.Json.Builder

type FunctionCall =
    { Name: string
      Args: float list }

    static member Decoder: Decoder<FunctionCall> =
        decoder {
            let! name = Decode.index 0 Decode.string
            let! numberOfArgs = Decode.index 1 Decode.int
            let! args =
                [ 2 .. numberOfArgs + 1 ]
                |> List.map (fun idx -> Decode.index idx Decode.float)
                |> Decode.all

            return { Name = name
                     Args = args }
        }

> Decode.fromString FunctionCall.Decoder """["square", 3, 1.23, 2, 42]"""
val it : Result<FunctionCall, string> = Ok { Name = "square"; Args = [1.23; 2; 42] }
```