### PR TITLE
optionalAt returns 'Ok None' even when the path does not exist

### DIFF
--- a/src/Decode.fs
+++ b/src/Decode.fs
@@ -352,8 +352,7 @@ module Decode =
                 | Some _ -> curPath, curValue, res
                 | None ->
                     if Helpers.isNullValue curValue then
-                        let res = badPathError fieldNames (Some curPath) firstValue
-                        curPath, curValue, Some res
+                        curPath, curValue, Some (Ok None)
                     elif Helpers.isObject curValue then
                         let curValue = Helpers.getField field curValue
                         curPath + "." + field, curValue, None

--- a/tests/Decoders.fs
+++ b/tests/Decoders.fs
@@ -1248,6 +1248,12 @@ Expecting a string but instead got: 12
 
                 equal expectedUndefinedField actualUndefinedField
 
+                let expectedUndefinedField = Ok(None)
+                let actualUndefinedField =
+                    Decode.fromString (Decode.optionalAt [ "data"; "something_undefined"; "name" ] Decode.string) json
+
+                equal expectedUndefinedField actualUndefinedField
+
             testCase "combining field and option decoders works" <| fun _ ->
                 let json = """{ "name": "maxime", "age": 25, "something_undefined": null }"""
 


### PR DESCRIPTION
The optionalAt Decoder returns `Error bad path` when the path does not exists ([checkout this repl scrip](https://fable.io/repl/#?code=LYewJgrgNgpgBAFRgZwC4Ch0gA4wHaIAWIqhAdAFLIh5a4EDKAnmjMJrKnKgE4CGeZHwDGqAJY1kcALxx0cOACJl8gN7yFSgG58oEFIoBccANobNm9ReubFPGADMY9vMJhGlAdgBiAJgDCAAwAWp6+vgBsANIAIr4A6gCsAJwA9ACMigA05ja2AEYgIADWYngA5jF8qO7Gir6BDQC06YFNgRHZuXlKfKAQeKgeVj15ijp6tUotDWQALJ5do2MDYkN1AKIAqgBKit15AL45ywp2bGs1PB540FAnp4rC9mBrINfGI6e2xFBgzgA5PpTRTBXQCMAgOAMDZLb62MT5AQeRQxDYADgivlankCjTx6V8AGZAq0yXD4Up8mJhCi0VsEGiABJM7GBfbfQ4HBRciwAXXQvKUyjk6FQTFwiH4ghE4hoMlyX00O0cznwbjgxjQPDK5TkNgAQkVShUAPpVGqauAWmAIMTAGAHACC-UGVv+wntugO-hebx4Vu1urgODltBsKuAl2cgd4wdDEnDmi56E43AAHjEYMJwDHjFmc-8eAAeBDSoSiRMAPgVFgLubIIHyACtsxgbAAKBwDODlGBcOBNGvcuCqfWjFVOFwa2R91BkFUARwgYheZG8YhgfyU9in6vc1uzDaDFXHPSNJV15uq8Fn-YXMGXq5gYHXm+3ikKl4qNsUh8LMBkGAN7iA6Z55JG0YBne84APLYGGuhkE6XAmOcUaoFcf4ANxKL8RZAg6ih8v+x5xqeI4KL6L7+jIvb3vBiFQMhqFPH6qDvDheEgH8gLAsRpH-GQJ56pRcAuiAAxcDBD5PmuKGmIofSSYMii4eMuj6AJ9ZCR6XpQOBFiHIZcAAJQcP2GbIDpeaCc4pblrKiZwFAYhoDW0i5DZZAOO+YDaJpBhwB23muWgGY2Tw5mYAoqaWfYUieRYvACBWYZSAAPjW3kODwIDAAw5F6qg6bWUeRa5Jg2A6oMDgEOcUgAKROn+CVAA&html=DwCwLgtgNgfAUAAlAUwIYBN4O0iyyoLhgAOAtMgI4CuAlgG4C8A5AMID2AdmMt2QCoBPEsmYIAxlx7cWPAB5gA9OGgBuCSFQAnAM75G1MADMyADmZYcwHeK20SYBDq3jGAIgD6HgBIB5AMr8XopQtABGOopaaOJgAHQkWuzo1LG0XHEQtJxxAFY6bjDAijZ2DpbY1rb2js6unj4BQR4h4ZHRqLFk6OwQCUkpaRlZOfmFxaU1FUihnADWCNFQ7jpgglDIOiDI+G5E0UbuXn6BwaERiuI6kWHUUBComdlxVwUIitPAswtLK2sbWx2YD2IAOR0apxa50ir0UqCgUCeOVeew+iCsq3WyGmigAVAhfJwoIIEJwduhkOgEEZ2FoELRJJwnKgICQNghcYp0dgXlJUNlkFoyDpaAAvTYIOJhKDscQLADe3Jw2HQtB0bNQggAXNSNnJVEqAL5K3ncflkoUi8U6SUMrgIRXK5VhTpzADmSWonHQZEkMq0OsEyAR7AA7ganTgHlo3dkdQAGBAAVhI+qNSom-2xcGK2wwWGAYWSJPEUFQ13cqBI5EZBAFWkKGdV9Hp6HcwayWzIVZIe1L5Z07fuapA3er40UzfgxSL6EE0+UkFgQA&css=Q))

Expected behavior : json is parsed correctly
Actual behavior:  
`Error Error at: $.values.[0].remitter
Expecting an object with path remitter.holderName but instead got:
{
    "reference": "7F2C0Z7226KD2W59/1",
    "bookingDate": "2020-10-06",
    "amount": {
        "value": "-120.47",
        "unit": "EUR"
    },
    "remitter": null,
    "creditor": {
        "holderName": "Zalando SE",
        "iban": "DE86210700200123010101",
        "bic": "DEUTDEHH210"
    }
}
Node holderName is unkown.`

Quoting Maxime from gitter: 
> I think the implementation of optionalAt is wrong. I mean if the value is optional then it should not matter if the path exist or not

This PR fixes this.