### PR TITLE
Pass parent to field coders

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.100"
+    "version": "3.1.100",
+    "rollForward": "minor"
   }
 }

--- a/src/Decode.fs
+++ b/src/Decode.fs
@@ -985,14 +985,14 @@ module Decode =
                 | Error _ -> acc
                 | Ok result ->
                     let path = path + "." + name
-                    let value = Helpers.getField name value
+                    let fieldValue = Helpers.getField name value
                     match Map.tryFind name fieldDecoders with
-                    | None -> decoder path value
+                    | None -> decoder path fieldValue
                     | Some fieldDecoder ->
-                        match fieldDecoder path (Option.ofObj value) with
+                        match fieldDecoder path value (Option.ofObj fieldValue) with
                         | UseOk v -> Ok v
                         | UseError e -> Error e
-                        | UseAutoDecoder -> decoder path value
+                        | UseAutoDecoder -> decoder path fieldValue
                     |> Result.map (fun v -> v::result))
 
     let inline private enumDecoder<'UnderlineType when 'UnderlineType : equality>
@@ -1070,7 +1070,7 @@ module Decode =
                 let decoders =
                     FSharpType.GetRecordFields(t, allowAccessToPrivateRepresentation=true)
                     |> Array.map (fun fi ->
-                        let name = Util.Casing.convert extra.CaseStrategy fi.Name
+                        let name = Casing.convert extra.CaseStrategy fi.Name
                         name, autoDecoder extra false fi.PropertyType)
                 fun path value ->
                     autoObject decoders fieldDecoders path value
@@ -1234,7 +1234,7 @@ module Decode =
         let fieldDecoders =
             extra |> Option.map (fun e ->
                 e.FieldDecoders |> Map.map (fun _ kvs ->
-                    kvs |> Seq.map (fun kv -> Util.Casing.convert caseStrategy kv.Key, kv.Value) |> Map))
+                    kvs |> Seq.map (fun kv -> Casing.convert caseStrategy kv.Key, kv.Value) |> Map))
         {
             CaseStrategy = caseStrategy
             Decoders = defaultArg decoders Map.empty

--- a/src/Encode.fs
+++ b/src/Encode.fs
@@ -401,7 +401,7 @@ module Encode =
                 let setters =
                     FSharpType.GetRecordFields(t, allowAccessToPrivateRepresentation=true)
                     |> Array.map (fun fi ->
-                        let targetKey = Util.Casing.convert extra.CaseStrategy fi.Name
+                        let targetKey = Casing.convert extra.CaseStrategy fi.Name
                         let encode = autoEncoder extra skipNullField fi.PropertyType
                         fun (source: obj) (target: JsonValue) ->
                             let value = FSharpValue.GetRecordField(source, fi)
@@ -409,7 +409,7 @@ module Encode =
                                 match Map.tryFind fi.Name fieldEncoders with
                                 | None -> target.[targetKey] <- encode value
                                 | Some fieldEncoder ->
-                                    match fieldEncoder value with
+                                    match fieldEncoder source value with
                                     | UseAutoEncoder -> target.[targetKey] <- encode value
                                     | UseJsonValue v -> target.[targetKey] <- v
                                     | IgnoreField -> ()

--- a/src/Types.fs
+++ b/src/Types.fs
@@ -36,7 +36,7 @@ type FieldDecoderResult =
     /// Let Thoth.Json decode the type using the Auto module, this is the default behaviour
     | UseAutoDecoder
 
-type FieldDecoder = string -> JsonValue option -> FieldDecoderResult
+type FieldDecoder = string -> JsonValue -> JsonValue option -> FieldDecoderResult
 
 type FieldEncoderResult =
     /// Use the given JsonValue for the output ignoring what Thoth.Json would have generated for the current field
@@ -46,7 +46,7 @@ type FieldEncoderResult =
     /// Let Thoth.Json generates the encoder automatically, this is the default behaviour
     | UseAutoEncoder
 
-type FieldEncoder = obj -> FieldEncoderResult
+type FieldEncoder = obj -> obj -> FieldEncoderResult
 
 type ExtraCoders =
     { Hash: string
@@ -82,10 +82,11 @@ module internal Util =
 #endif
 
 
-    module Casing =
-        let lowerFirst (str : string) = str.[..0].ToLowerInvariant() + str.[1..]
-        let convert caseStrategy fieldName =
-            match caseStrategy with
-            | CamelCase -> lowerFirst fieldName
-            | SnakeCase -> Regex.Replace(lowerFirst fieldName, "[A-Z]","_$0").ToLowerInvariant()
-            | PascalCase -> fieldName
+module Casing =
+    let lowerFirst (str : string) = str.[..0].ToLowerInvariant() + str.[1..]
+
+    let convert caseStrategy fieldName =
+        match caseStrategy with
+        | CamelCase -> lowerFirst fieldName
+        | SnakeCase -> Regex.Replace(lowerFirst fieldName, "[A-Z]","_$0").ToLowerInvariant()
+        | PascalCase -> fieldName


### PR DESCRIPTION
Sorry, not sure which branch is supposed to be the target for PRs now, so I'm using `develop` :) I'm playing with the field custom decoders doing migrations in JSON documents and I realized it would be helpful to have access to the parent from the field coder in case we need to access another field and make some transformation. Example:

```fsharp
Extra.empty
|> Extra.withCustomFieldDecoder fieldName (fun _path parent value ->
    match value with
    | Some _ -> UseAutoDecoder
    | None ->
        let anotherFieldName = Casing.convert caseStrategy "AnotherField"
        let anotherFieldDecoder = Decode.field anotherFieldName Decode.string
        match anotherFieldDecoder "$" parent with
        | Error er -> UseError er
        | Ok v -> someTransformation v |> UseOk)
```

Note this PR also exposes the `Casing` module so we can convert the field names manually. It seems the field custom coders feature is not yet released so this shouldn't break anything :)