### PR TITLE
Improve tree shaking for longs

### DIFF
--- a/src/Decode.fs
+++ b/src/Decode.fs
@@ -160,15 +160,15 @@ module Decode =
     let inline private integral
                     (name : string)
                     (tryParse : (string -> bool * 'T))
-                    (min : 'T)
-                    (max : 'T)
+                    (min : unit->'T)
+                    (max : unit->'T)
                     (conv : float -> 'T) : Decoder< 'T > =
 
         fun path value ->
             if Helpers.isNumber value then
                 let value : float = unbox value
                 if Helpers.isIntegralValue value then
-                    if (float min) <= value && value <= (float max) then
+                    if (float(min())) <= value && value <= (float(max())) then
                         Ok(conv value)
                     else
                         (path, BadPrimitiveExtra(name, value, "Value was either too large or too small for " + name)) |> Error
@@ -185,8 +185,8 @@ module Decode =
         integral
             "a sbyte"
             System.SByte.TryParse
-            System.SByte.MinValue
-            System.SByte.MaxValue
+            (fun () -> System.SByte.MinValue)
+            (fun () -> System.SByte.MaxValue)
             sbyte
 
     /// Alias to Decode.uint8
@@ -194,59 +194,59 @@ module Decode =
         integral
             "a byte"
             System.Byte.TryParse
-            System.Byte.MinValue
-            System.Byte.MaxValue
+            (fun () -> System.Byte.MinValue)
+            (fun () -> System.Byte.MaxValue)
             byte
 
     let int16 : Decoder<int16> =
         integral
             "an int16"
             System.Int16.TryParse
-            System.Int16.MinValue
-            System.Int16.MaxValue
+            (fun () -> System.Int16.MinValue)
+            (fun () -> System.Int16.MaxValue)
             int16
 
     let uint16 : Decoder<uint16> =
         integral
             "an uint16"
             System.UInt16.TryParse
-            System.UInt16.MinValue
-            System.UInt16.MaxValue
+            (fun () -> System.UInt16.MinValue)
+            (fun () -> System.UInt16.MaxValue)
             uint16
 
     let int : Decoder<int> =
         integral
             "an int"
             System.Int32.TryParse
-            System.Int32.MinValue
-            System.Int32.MaxValue
+            (fun () -> System.Int32.MinValue)
+            (fun () -> System.Int32.MaxValue)
             int
 
     let uint32 : Decoder<uint32> =
         integral
             "an uint32"
             System.UInt32.TryParse
-            System.UInt32.MinValue
-            System.UInt32.MaxValue
+            (fun () -> System.UInt32.MinValue)
+            (fun () -> System.UInt32.MaxValue)
             uint32
 
     let int64 : Decoder<int64> =
         integral
             "an int64"
             System.Int64.TryParse
-            System.Int64.MinValue
-            System.Int64.MaxValue
+            (fun () -> System.Int64.MinValue)
+            (fun () -> System.Int64.MaxValue)
             int64
 
     let uint64 : Decoder<uint64> =
         integral
             "an uint64"
             System.UInt64.TryParse
-            System.UInt64.MinValue
-            System.UInt64.MaxValue
+            (fun () -> System.UInt64.MinValue)
+            (fun () -> System.UInt64.MaxValue)
             uint64
 
-    let bigint : Decoder<bigint> =
+let bigint : Decoder<bigint> =
         fun path value ->
             if Helpers.isNumber value then
                 Helpers.asInt value |> bigint |> Ok

--- a/src/Decode.fs
+++ b/src/Decode.fs
@@ -246,7 +246,7 @@ module Decode =
             (fun () -> System.UInt64.MaxValue)
             uint64
 
-let bigint : Decoder<bigint> =
+    let bigint : Decoder<bigint> =
         fun path value ->
             if Helpers.isNumber value then
                 Helpers.asInt value |> bigint |> Ok


### PR DESCRIPTION
I was trying to remove the dependencies of decimal and long types when not needed. However when testing with fulma-demo the code for long.js was always included in the bundle. After a lot of investigation I realized the issue was in the `Decode.integral` helper of Thoth.Json: min/max values are passed directly when generating the custom functions, which makes F# cache the values. This is correct behavior but unfortunately it causes a side effect that makes the long.js code get included in the bundle even if `int64`, `uint64` helpers are not used. This should fix it (together with another fix coming in next Fable release).