### PR TITLE
Fix path when auto decoding unions

### DIFF
--- a/src/Decode.fs
+++ b/src/Decode.fs
@@ -1090,8 +1090,8 @@ module Decode =
                         makeUnion extra caseStrategy t name path [||]
                     elif Helpers.isArray(value) then
                         let values = Helpers.asArray value
-                        let name = Helpers.asString values.[0]
-                        makeUnion extra caseStrategy t name path values
+                        string (path + "[0]") values.[0]
+                        |> Result.bind (fun name -> makeUnion extra caseStrategy t name path values)
                     else (path, BadPrimitive("a string or array", value)) |> Error
 
             else

--- a/src/Thoth.Json.fsproj
+++ b/src/Thoth.Json.fsproj
@@ -24,7 +24,7 @@ If you are interested on using it against .NET Core or .NET Framework, please us
     <Compile Include="Extra.fs" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="*.fsproj; **\*.fs; **\*.js" PackagePath="fable" />
+    <Content Include="*.fsproj; **\*.fs; **\*.js; package.json" PackagePath="fable" />
   </ItemGroup>
   <Import Project="..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/package.json
+++ b/src/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "sideEffects": false
+}

--- a/tests/Decoders.fs
+++ b/tests/Decoders.fs
@@ -33,6 +33,8 @@ open Tests.Types
 
 type RecordWithPrivateConstructor = private { Foo1: int; Foo2: float }
 type UnionWithPrivateConstructor = private Bar of string | Baz
+type UnionWithMultipleFields = Multi of string * int * float
+
 let tests : Test =
     testList "Thoth.Json.Decode" [
 
@@ -2888,6 +2890,11 @@ Reason: Unkown value provided for the enum
                 let json = """[ "Baz", ["Bar", "foo"]]"""
                 Decode.Auto.fromString<UnionWithPrivateConstructor list>(json, caseStrategy=CamelCase)
                 |> equal (Ok [Baz; Bar "foo"])
+
+            testCase "Auto.fromString works gives proper error for wrong union fields" <| fun _ ->
+                let json = """["Multi", "bar", "foo", "zas"]"""
+                Decode.Auto.fromString<UnionWithMultipleFields>(json, caseStrategy=CamelCase)
+                |> equal (Error "Error at: `$[2]`\nExpecting an int but instead got: \"foo\"")
 
             testCase "Auto.generateDecoderCached works" <| fun _ ->
                 let expected = Ok { Id = 0; Name = "maxime"; Email = "mail@domain.com"; Followers = 0 }

--- a/tests/Decoders.fs
+++ b/tests/Decoders.fs
@@ -2896,6 +2896,17 @@ Reason: Unkown value provided for the enum
                 Decode.Auto.fromString<UnionWithMultipleFields>(json, caseStrategy=CamelCase)
                 |> equal (Error "Error at: `$[2]`\nExpecting an int but instead got: \"foo\"")
 
+            // TODO: Should we allow shorter arrays when last fields are options?
+            testCase "Auto.fromString works gives proper error for wrong array length" <| fun _ ->
+                let json = """["Multi", "bar", 1]"""
+                Decode.Auto.fromString<UnionWithMultipleFields>(json, caseStrategy=CamelCase)
+                |> equal (Error "Error at: `$`\nThe following `failure` occurred with the decoder: Expected array of length 4 but got 3")
+
+            testCase "Auto.fromString works gives proper error for wrong case name" <| fun _ ->
+                let json = """[1]"""
+                Decode.Auto.fromString<UnionWithMultipleFields>(json, caseStrategy=CamelCase)
+                |> equal (Error "Error at: `$[0]`\nExpecting a string but instead got: 1")
+
             testCase "Auto.generateDecoderCached works" <| fun _ ->
                 let expected = Ok { Id = 0; Name = "maxime"; Email = "mail@domain.com"; Followers = 0 }
                 let json = """{ "id" : 0, "name": "maxime", "email": "mail@domain.com", "followers": 0 }"""


### PR DESCRIPTION
I realized that, when using an autodecoder for unions and there's an error in one of the fields, the index of the field is not shown in the path which makes it more difficult to spot the problem. This fixes it.

I also took the chance to add a package.json in this PR with the `sideEffects` field set to false. In principle this should enable better tree shaking for Thoth.Json files.