### PR TITLE
Fix #144: Auto coders for nested anon records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * PR #118: Fix path when auto decoding unions (by @alfonsogarciacaro)
+* PR #145: Fix auto coders for nested anon records  (by @alfonsogarciacaro)
 
 ### Added
 

--- a/src/Decode.fs
+++ b/src/Decode.fs
@@ -1078,7 +1078,12 @@ module Decode =
     and private autoDecodeRecordsAndUnions extra (caseStrategy : CaseStrategy) (isOptional : bool) (t: System.Type) : BoxedDecoder =
         // Add the decoder to extra in case one of the fields is recursive
         let decoderRef = ref Unchecked.defaultof<_>
-        let extra = extra |> Map.add t.FullName decoderRef
+        let extra =
+            // As of 3.7.17 Fable assigns empty name to anonymous record, we shouldn't add them to the map to avoid conflicts.
+            // Anonymous records cannot be recursive anyways, see #144
+            match t.FullName with
+            | "" -> extra
+            | fullName -> extra |> Map.add fullName decoderRef
         let decoder =
             if FSharpType.IsRecord(t, allowAccessToPrivateRepresentation=true) then
                 let decoders =

--- a/src/Encode.fs
+++ b/src/Encode.fs
@@ -391,8 +391,13 @@ module Encode =
 
     let rec private autoEncodeRecordsAndUnions extra (caseStrategy : CaseStrategy) (skipNullField : bool) (t: System.Type) : BoxedEncoder =
         // Add the encoder to extra in case one of the fields is recursive
-        let encoderRef = ref Unchecked.defaultof<_>
-        let extra = extra |> Map.add t.FullName encoderRef
+        let encoderRef = ref Unchecked.defaultof<_>        
+        let extra =
+            // As of 3.7.17 Fable assigns empty name to anonymous record, we shouldn't add them to the map to avoid conflicts.
+            // Anonymous records cannot be recursive anyways, see #144
+            match t.FullName with
+            | "" -> extra
+            | fullName -> extra |> Map.add fullName encoderRef
         let encoder =
             if FSharpType.IsRecord(t, allowAccessToPrivateRepresentation=true) then
                 let setters =

--- a/tests/Decoders.fs
+++ b/tests/Decoders.fs
@@ -2824,6 +2824,18 @@ Reason: Unkown value provided for the enum
                 let res = Decode.Auto.unsafeFromString<obj>(json)
                 equal value res
 
+            testCase "Auto decoders works for anonymous record" <| fun _ ->
+                let value = {| A = "string" |}
+                let json = Encode.Auto.toString(4, value)
+                let res = Decode.Auto.unsafeFromString(json)
+                equal value res
+
+            testCase "Auto decoders works for nested anonymous record" <| fun _ ->
+                let value = {| A = {| B = "string" |} |}
+                let json = Encode.Auto.toString(4, value)
+                let res = Decode.Auto.unsafeFromString(json)
+                equal value res
+
             testCase "Auto decoders works even if type is determined by the compiler" <| fun _ ->
                 let value = [1; 2; 3; 4]
                 let json = Encode.Auto.toString(4, value)


### PR DESCRIPTION
Fix #144: The problem was Fable assigns an empty name for anonymous records, which conflicts with the internal coder map when having multiple anonymous records. Maybe Fable should assign a name to anonymous records same as dotnet F# does, but giving that anonymous records are represented as plain JS objects, for now the simplest solution is to avoid adding anonymous records to the internal map (they cannot be recursive so there's actually no need for it).