### PR TITLE
Extend the DateTime decoding API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * PR 136: Add `Decode.map'` and `Encode.map` to support `Map<'Key, 'Value>` (by @njlr)
+* PR 146: Add `Decode.datetimeUtc`, `Decode.datetimeLocal` (by @Gastove)
+
+### Deprecated
+
+* PR 146: Mark `Decode.datetime` as deprecated (by @Gastove)
 
 ## 7.0.0 - 2022-01-05
 

--- a/src/Decode.fs
+++ b/src/Decode.fs
@@ -292,11 +292,32 @@ module Decode =
             else
                 (path, BadPrimitive("a decimal", value)) |> Error
 
+    [<System.Obsolete("Please use datetimeUTC instead.")>]
     let datetime : Decoder<System.DateTime> =
         fun path value ->
             if Helpers.isString value then
                 match System.DateTime.TryParse (Helpers.asString value) with
                 | true, x -> x.ToUniversalTime() |> Ok
+                | _ -> (path, BadPrimitive("a datetime", value)) |> Error
+            else
+                (path, BadPrimitive("a datetime", value)) |> Error
+
+    /// Decode a System.DateTime value using Sytem.DateTime.TryParse, then convert it to UTC.
+    let datetimeUTC : Decoder<System.DateTime> =
+        fun path value ->
+            if Helpers.isString value then
+                match System.DateTime.TryParse (Helpers.asString value) with
+                | true, x -> x.ToUniversalTime() |> Ok
+                | _ -> (path, BadPrimitive("a datetime", value)) |> Error
+            else
+                (path, BadPrimitive("a datetime", value)) |> Error
+
+    /// Decode a System.DateTime with DateTime.TryParse; uses default System.DateTimeStyles.
+    let datetimeLocal : Decoder<System.DateTime> =
+        fun path value ->
+            if Helpers.isString value then
+                match System.DateTime.TryParse (Helpers.asString value) with
+                | true, x -> x |> Ok
                 | _ -> (path, BadPrimitive("a datetime", value)) |> Error
             else
                 (path, BadPrimitive("a datetime", value)) |> Error

--- a/src/Decode.fs
+++ b/src/Decode.fs
@@ -292,7 +292,7 @@ module Decode =
             else
                 (path, BadPrimitive("a decimal", value)) |> Error
 
-    [<System.Obsolete("Please use datetimeUTC instead.")>]
+    [<System.Obsolete("Please use datetimeUtc instead.")>]
     let datetime : Decoder<System.DateTime> =
         fun path value ->
             if Helpers.isString value then
@@ -303,7 +303,7 @@ module Decode =
                 (path, BadPrimitive("a datetime", value)) |> Error
 
     /// Decode a System.DateTime value using Sytem.DateTime.TryParse, then convert it to UTC.
-    let datetimeUTC : Decoder<System.DateTime> =
+    let datetimeUtc : Decoder<System.DateTime> =
         fun path value ->
             if Helpers.isString value then
                 match System.DateTime.TryParse (Helpers.asString value) with

--- a/tests/Decoders.fs
+++ b/tests/Decoders.fs
@@ -514,7 +514,14 @@ Expecting a bigint but instead got: "maxime"
             testCase "a datetime works" <| fun _ ->
                 let expected = new DateTime(2018, 10, 1, 11, 12, 55, DateTimeKind.Utc)
                 let actual =
-                    Decode.fromString Decode.datetime "\"2018-10-01T11:12:55.00Z\""
+                    Decode.fromString Decode.datetimeUTC "\"2018-10-01T11:12:55.00Z\""
+
+                equal (Ok expected) actual
+
+            testCase "a non-UTC datetime works" <| fun _ ->
+                let expected = new DateTime(2018, 10, 1, 11, 12, 55)
+                let actual =
+                    Decode.fromString Decode.datetimeLocal "\"2018-10-01T11:12:55\""
 
                 equal (Ok expected) actual
 
@@ -527,7 +534,7 @@ Expecting a datetime but instead got: "invalid_string"
                         """.Trim())
 
                 let actual =
-                    Decode.fromString Decode.datetime "\"invalid_string\""
+                    Decode.fromString Decode.datetimeUTC "\"invalid_string\""
 
                 equal expected actual
 
@@ -537,7 +544,7 @@ Expecting a datetime but instead got: "invalid_string"
                 let expected = Ok (localDate.ToUniversalTime())
                 let json = sprintf "\"%s\"" (localDate.ToString("O"))
                 let actual =
-                    Decode.fromString Decode.datetime json
+                    Decode.fromString Decode.datetimeLocal json
 
                 equal expected actual
 
@@ -826,7 +833,7 @@ Expecting a datetime but instead got: false
                             Decode.string
                             Decode.float
                             SmallRecord.Decoder
-                            Decode.datetime) json
+                            Decode.datetimeUTC) json
 
                 equal expected actual
 
@@ -846,7 +853,7 @@ Expecting null but instead got: false
                             Decode.string
                             Decode.float
                             SmallRecord.Decoder
-                            Decode.datetime
+                            Decode.datetimeUTC
                             (Decode.nil null)) json
 
                 equal expected actual
@@ -867,7 +874,7 @@ Expecting an int but instead got: false
                             Decode.string
                             Decode.float
                             SmallRecord.Decoder
-                            Decode.datetime
+                            Decode.datetimeUTC
                             (Decode.nil null)
                             Decode.int) json
 
@@ -889,7 +896,7 @@ Expecting an int but instead got: "maxime"
                             Decode.string
                             Decode.float
                             SmallRecord.Decoder
-                            Decode.datetime
+                            Decode.datetimeUTC
                             (Decode.nil null)
                             Decode.int
                             Decode.int) json

--- a/tests/Decoders.fs
+++ b/tests/Decoders.fs
@@ -514,7 +514,7 @@ Expecting a bigint but instead got: "maxime"
             testCase "a datetime works" <| fun _ ->
                 let expected = new DateTime(2018, 10, 1, 11, 12, 55, DateTimeKind.Utc)
                 let actual =
-                    Decode.fromString Decode.datetimeUTC "\"2018-10-01T11:12:55.00Z\""
+                    Decode.fromString Decode.datetimeUtc "\"2018-10-01T11:12:55.00Z\""
 
                 equal (Ok expected) actual
 
@@ -534,7 +534,7 @@ Expecting a datetime but instead got: "invalid_string"
                         """.Trim())
 
                 let actual =
-                    Decode.fromString Decode.datetimeUTC "\"invalid_string\""
+                    Decode.fromString Decode.datetimeUtc "\"invalid_string\""
 
                 equal expected actual
 
@@ -544,7 +544,7 @@ Expecting a datetime but instead got: "invalid_string"
                 let expected = Ok (localDate.ToUniversalTime())
                 let json = sprintf "\"%s\"" (localDate.ToString("O"))
                 let actual =
-                    Decode.fromString Decode.datetimeLocal json
+                    Decode.fromString Decode.datetimeUtc json
 
                 equal expected actual
 
@@ -833,7 +833,7 @@ Expecting a datetime but instead got: false
                             Decode.string
                             Decode.float
                             SmallRecord.Decoder
-                            Decode.datetimeUTC) json
+                            Decode.datetimeUtc) json
 
                 equal expected actual
 
@@ -853,7 +853,7 @@ Expecting null but instead got: false
                             Decode.string
                             Decode.float
                             SmallRecord.Decoder
-                            Decode.datetimeUTC
+                            Decode.datetimeUtc
                             (Decode.nil null)) json
 
                 equal expected actual
@@ -874,7 +874,7 @@ Expecting an int but instead got: false
                             Decode.string
                             Decode.float
                             SmallRecord.Decoder
-                            Decode.datetimeUTC
+                            Decode.datetimeUtc
                             (Decode.nil null)
                             Decode.int) json
 
@@ -896,7 +896,7 @@ Expecting an int but instead got: "maxime"
                             Decode.string
                             Decode.float
                             SmallRecord.Decoder
-                            Decode.datetimeUTC
+                            Decode.datetimeUtc
                             (Decode.nil null)
                             Decode.int
                             Decode.int) json


### PR DESCRIPTION
The current API has the behavior of decoding a given time, then converting it to UTC. This leads to confusing behavior, e.g. in unit tests when a given string doesn't parse to the same datetime it represents. There's some discussion of this in [issue 107](https://github.com/thoth-org/Thoth.Json/issues/107).

I've elected to try adjusting this with two methods discussed in #107. This deprecates the `datetime` decoder, and adds two new decoders, `datetimeUTC` and `datetimeLocal`.

I've tried to update the tests, but -- and this is silly -- I can't seem to get them to _run_. The `tests` project is written as a library, not an executable, so running `dotnet test` does nothing, and it cannot be `dotnet run`. `fake-cli` is in the tool manifest, but there's no build script. The Azure CI configs call a script called `fake.sh`, which doesn't exist in the project. I can't find a `CONTRIBUTING.md` or similar, so I'm just... a bit lost. If a maintainer can let me know how the tests work, I'm happy to run them, make sure they pass.

Thanks for the great project! Thoth is a pleasure to use.

Closes #107.