### PR TITLE
make decode process successful by fixing GUID error in docs

### DIFF
--- a/docs/documentation/manual/introduction.fsx
+++ b/docs/documentation/manual/introduction.fsx
@@ -40,7 +40,7 @@ let json =
     """
 {
     "data": {
-        "id": "9d9d9d9d-9d9d-9d9d-9d9d-9d9d9d9d9d9",
+        "id": "9d9d9d9d-9d9d-9d9d-9d9d-9d9d9d9d9d9d",
         "name": "Triss Merigold",
         "age": 42
     }


### PR DESCRIPTION
In the manual example json, the value of field named id, which is supposed to be a valid GUID to decode successfully but it lacks a character after the lasting seperating hyphen. By adding a character in that place, use thoth.json to decode the json string will work, which may be friendly to newcomer to learn F# and the library.