### PR TITLE
fix: packaged lib has esm js files

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -1,4 +1,5 @@
 {
   "private": true,
-  "sideEffects": false
+  "sideEffects": false,
+  "type": "module"
 }


### PR DESCRIPTION
since this seems to be the package.json that ultimately ends up in `fable_modules` - and is thus referenced when _not_ using a bundler (e.g. node environment with jest testing) the contained files should also be marked as being esm.

Considered (and tried) alternatives:
- treat `.fs.js` as esm: this doesn't seem to apply to gitignored code and not every library has that option
- transform on demand: also not supported by every library and quite tedious and error prone to set up