### PR TITLE
Use name to call optional argument

### DIFF
--- a/src/Encode.fs
+++ b/src/Encode.fs
@@ -363,7 +363,7 @@ module Encode =
     ///**Exceptions**
     ///
     let toString (space: int) (value: JsonValue) : string =
-       JS.JSON.stringify(value, !!null, space)
+       JS.JSON.stringify(value, space=space)
 
     ///**Description**
     /// Encode an option


### PR DESCRIPTION
I was making some changes to Fable uncurrying mechanism and this caused problems. I've made it so it still works, but anyways it's better to use named argument instead of casting null.