### PR TITLE
Fix CultureInfo for decimal and windows ci

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fable": {
-      "version": "4.8.0",
+      "version": "4.8.1",
       "commands": [
         "fable"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fable": {
-      "version": "4.8.1",
+      "version": "4.9.0",
       "commands": [
         "fable"
       ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10' 
+      - run: python --version
       - name: Test (Unix)
         if: matrix.platform == 'ubuntu-latest' || matrix.platform == 'macOS-latest'
         run: ./build.sh test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,11 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '20'
+      - name: Install Python (Windows)
+        if: matrix.platform == 'windows-latest'
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10' 
       - name: Test (Unix)
         if: matrix.platform == 'ubuntu-latest' || matrix.platform == 'macOS-latest'
         run: ./build.sh test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '20'
-      # - name: Install and use custom npm version
-      #   run: npm i -g npm@7
-      # - name: Install dependencies
-      #   run: npm install
       - name: Test (Unix)
         if: matrix.platform == 'ubuntu-latest' || matrix.platform == 'macOS-latest'
         run: ./build.sh test

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="BlackFox.CommandLine" Version="1.0.0" />
     <PackageVersion Include="Fable.Python" Version="4.3.0" />
-    <PackageVersion Include="Fable.Pyxpecto" Version="0.3.0" />
+    <PackageVersion Include="Fable.Pyxpecto" Version="1.0.1" />
     <PackageVersion Include="FSharp.Core" Version="5.0.0" />
     <!--
         We use an older version of Expecto to keep FSharp.Core version as low as possible
@@ -17,6 +17,6 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageVersion Include="Semver" Version="2.3.0" />
     <PackageVersion Include="SimpleExec" Version="11.0.0" />
-    <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.1.1"/>
+    <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.1.1" />
   </ItemGroup>
 </Project>

--- a/build.bat
+++ b/build.bat
@@ -1,4 +1,5 @@
 @echo off
 
+set PYTHONIOENCODING=utf-8
 dotnet tool restore
 dotnet run --project build/Build.fsproj -- %*

--- a/build/Test/Python.fs
+++ b/build/Test/Python.fs
@@ -26,6 +26,7 @@ let handle (args: string list) =
         |> CmdLine.appendRaw runArg
         |> CmdLine.appendRaw "python"
         |> CmdLine.appendRaw "fableBuild/main.py"
+        |> CmdLine.appendRaw "--silent"
         |> CmdLine.toString,
         workingDirectory = Workspace.ProjectDir.Tests.python
     )

--- a/packages/Thoth.Json.Core/Encode.fs
+++ b/packages/Thoth.Json.Core/Encode.fs
@@ -15,7 +15,9 @@ module Encode =
     let float32 (value: float32) =
         Json.DecimalNumber(Operators.float value)
 
-    let inline decimal (value: decimal) = value.ToString() |> string
+    let inline decimal (value: decimal) =
+        value.ToString(CultureInfo.InvariantCulture) |> string
+
     let inline nil<'T> = Json.Null
     let inline bool value = Json.Boolean value
     let inline object values = Json.Object values

--- a/packages/Thoth.Json.Core/Encode.fs
+++ b/packages/Thoth.Json.Core/Encode.fs
@@ -15,14 +15,7 @@ module Encode =
     let float32 (value: float32) =
         Json.DecimalNumber(Operators.float value)
 
-    let inline private _toString (a: 'a :> IConvertible) =
-#if !FABLE_COMPILER
-        a.ToString(new System.Globalization.CultureInfo("en-US"))
-#else
-        a.ToString()
-#endif
-
-    let inline decimal (value: decimal) = _toString value |> string
+    let inline decimal (value: decimal) = value.ToString() |> string
     let inline nil<'T> = Json.Null
     let inline bool value = Json.Boolean value
     let inline object values = Json.Object values

--- a/packages/Thoth.Json.Core/Encode.fs
+++ b/packages/Thoth.Json.Core/Encode.fs
@@ -15,7 +15,14 @@ module Encode =
     let float32 (value: float32) =
         Json.DecimalNumber(Operators.float value)
 
-    let inline decimal (value: decimal) = value.ToString() |> string
+    let inline private _toString (a: 'a :> IConvertible) =
+#if !FABLE_COMPILER
+        a.ToString(new System.Globalization.CultureInfo("en-US"))
+#else
+        a.ToString()
+#endif
+
+    let inline decimal (value: decimal) = _toString value |> string
     let inline nil<'T> = Json.Null
     let inline bool value = Json.Boolean value
     let inline object values = Json.Object values

--- a/tests/Thoth.Json.Tests.JavaScript/Main.fs
+++ b/tests/Thoth.Json.Tests.JavaScript/Main.fs
@@ -20,6 +20,7 @@ type JavascriptTestRunner() =
 
     override _.testList = testList
     override _.testCase = testCase
+    override _.ftestCase = ftestCase
 
     override _.equal a b = Assert.AreEqual(b, a)
 

--- a/tests/Thoth.Json.Tests.JavaScript/packages.lock.json
+++ b/tests/Thoth.Json.Tests.JavaScript/packages.lock.json
@@ -2,6 +2,18 @@
   "version": 2,
   "dependencies": {
     ".NETStandard,Version=v2.0": {
+      "DotNet.ReproducibleBuilds": {
+        "type": "Direct",
+        "requested": "[1.1.1, )",
+        "resolved": "1.1.1",
+        "contentHash": "+H2t/t34h6mhEoUvHi8yGXyuZ2GjSovcGYehJrS2MDm2XgmPfZL2Sdxg+uL2lKgZ4M6tTwKHIlxOob2bgh0NRQ==",
+        "dependencies": {
+          "Microsoft.SourceLink.AzureRepos.Git": "1.1.1",
+          "Microsoft.SourceLink.Bitbucket.Git": "1.1.1",
+          "Microsoft.SourceLink.GitHub": "1.1.1",
+          "Microsoft.SourceLink.GitLab": "1.1.1"
+        }
+      },
       "Fable.Core": {
         "type": "Direct",
         "requested": "[4.1.0, )",
@@ -33,10 +45,56 @@
           "Microsoft.NETCore.Platforms": "1.1.0"
         }
       },
+      "Microsoft.Build.Tasks.Git": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "AT3HlgTjsqHnWpBHSNeR0KxbLZD7bztlZVj7I8vgeYG9SYqbeFGh0TM/KVtC6fg53nrWHl3VfZFvb5BiQFcY6Q=="
+      },
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
         "resolved": "1.1.0",
         "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
+      },
+      "Microsoft.SourceLink.AzureRepos.Git": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "qB5urvw9LO2bG3eVAkuL+2ughxz2rR7aYgm2iyrB8Rlk9cp2ndvGRCvehk3rNIhRuNtQaeKwctOl1KvWiklv5w==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "1.1.1",
+          "Microsoft.SourceLink.Common": "1.1.1"
+        }
+      },
+      "Microsoft.SourceLink.Bitbucket.Git": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "cDzxXwlyWpLWaH0em4Idj0H3AmVo3L/6xRXKssYemx+7W52iNskj/SQ4FOmfCb8YQt39otTDNMveCZzYtMoucQ==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "1.1.1",
+          "Microsoft.SourceLink.Common": "1.1.1"
+        }
+      },
+      "Microsoft.SourceLink.Common": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "WMcGpWKrmJmzrNeuaEb23bEMnbtR/vLmvZtkAP5qWu7vQsY59GqfRJd65sFpBszbd2k/bQ8cs8eWawQKAabkVg=="
+      },
+      "Microsoft.SourceLink.GitHub": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "IaJGnOv/M7UQjRJks7B6p7pbPnOwisYGOIzqCz5ilGFTApZ3ktOR+6zJ12ZRPInulBmdAf1SrGdDG2MU8g6XTw==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "1.1.1",
+          "Microsoft.SourceLink.Common": "1.1.1"
+        }
+      },
+      "Microsoft.SourceLink.GitLab": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "tvsg47DDLqqedlPeYVE2lmiTpND8F0hkrealQ5hYltSmvruy/Gr5nHAKSsjyw5L3NeM/HLMI5ORv7on/M4qyZw==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "1.1.1",
+          "Microsoft.SourceLink.Common": "1.1.1"
+        }
       },
       "thoth.json.core": {
         "type": "Project",

--- a/tests/Thoth.Json.Tests.Newtonsoft/Main.fs
+++ b/tests/Thoth.Json.Tests.Newtonsoft/Main.fs
@@ -18,8 +18,9 @@ type NewtonsoftTestRunner() =
 
     override _.testList = testList
     override _.testCase = testCase
+    override _.ftestCase = ftestCase
 
-    override _.equal a b = Expect.equal a b ""
+    override _.equal actual expected = Expect.equal actual expected ""
 
     override _.Encode = NewtonsoftEncode()
 

--- a/tests/Thoth.Json.Tests.Newtonsoft/packages.lock.json
+++ b/tests/Thoth.Json.Tests.Newtonsoft/packages.lock.json
@@ -2,6 +2,18 @@
   "version": 2,
   "dependencies": {
     "net8.0": {
+      "DotNet.ReproducibleBuilds": {
+        "type": "Direct",
+        "requested": "[1.1.1, )",
+        "resolved": "1.1.1",
+        "contentHash": "+H2t/t34h6mhEoUvHi8yGXyuZ2GjSovcGYehJrS2MDm2XgmPfZL2Sdxg+uL2lKgZ4M6tTwKHIlxOob2bgh0NRQ==",
+        "dependencies": {
+          "Microsoft.SourceLink.AzureRepos.Git": "1.1.1",
+          "Microsoft.SourceLink.Bitbucket.Git": "1.1.1",
+          "Microsoft.SourceLink.GitHub": "1.1.1",
+          "Microsoft.SourceLink.GitLab": "1.1.1"
+        }
+      },
       "Expecto": {
         "type": "Direct",
         "requested": "[9.0.4, )",
@@ -17,6 +29,52 @@
         "requested": "[5.0.0, )",
         "resolved": "5.0.0",
         "contentHash": "iHoYXA0VaSQUONGENB1aVafjDDZDZpwu39MtaRCTrmwFW/cTcK0b2yKNVYneFHJMc3ChtsSoM9lNtJ1dYXkHfA=="
+      },
+      "Microsoft.Build.Tasks.Git": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "AT3HlgTjsqHnWpBHSNeR0KxbLZD7bztlZVj7I8vgeYG9SYqbeFGh0TM/KVtC6fg53nrWHl3VfZFvb5BiQFcY6Q=="
+      },
+      "Microsoft.SourceLink.AzureRepos.Git": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "qB5urvw9LO2bG3eVAkuL+2ughxz2rR7aYgm2iyrB8Rlk9cp2ndvGRCvehk3rNIhRuNtQaeKwctOl1KvWiklv5w==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "1.1.1",
+          "Microsoft.SourceLink.Common": "1.1.1"
+        }
+      },
+      "Microsoft.SourceLink.Bitbucket.Git": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "cDzxXwlyWpLWaH0em4Idj0H3AmVo3L/6xRXKssYemx+7W52iNskj/SQ4FOmfCb8YQt39otTDNMveCZzYtMoucQ==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "1.1.1",
+          "Microsoft.SourceLink.Common": "1.1.1"
+        }
+      },
+      "Microsoft.SourceLink.Common": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "WMcGpWKrmJmzrNeuaEb23bEMnbtR/vLmvZtkAP5qWu7vQsY59GqfRJd65sFpBszbd2k/bQ8cs8eWawQKAabkVg=="
+      },
+      "Microsoft.SourceLink.GitHub": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "IaJGnOv/M7UQjRJks7B6p7pbPnOwisYGOIzqCz5ilGFTApZ3ktOR+6zJ12ZRPInulBmdAf1SrGdDG2MU8g6XTw==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "1.1.1",
+          "Microsoft.SourceLink.Common": "1.1.1"
+        }
+      },
+      "Microsoft.SourceLink.GitLab": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "tvsg47DDLqqedlPeYVE2lmiTpND8F0hkrealQ5hYltSmvruy/Gr5nHAKSsjyw5L3NeM/HLMI5ORv7on/M4qyZw==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "1.1.1",
+          "Microsoft.SourceLink.Common": "1.1.1"
+        }
       },
       "Mono.Cecil": {
         "type": "Transitive",

--- a/tests/Thoth.Json.Tests.Python/Main.fs
+++ b/tests/Thoth.Json.Tests.Python/Main.fs
@@ -21,6 +21,7 @@ type PythonTestRunner() =
 
     override _.testList = testList
     override _.testCase = testCase
+    override _.ftestCase = ftestCase
 
     override _.equal a b = Expect.equal b a ""
 

--- a/tests/Thoth.Json.Tests.Python/Main.fs
+++ b/tests/Thoth.Json.Tests.Python/Main.fs
@@ -7,6 +7,7 @@ open Thoth.Json.Python
 open System
 open Thoth.Json.Tests.Types
 open Fable.Core.Testing
+open Fable.Pyxpecto.Model
 
 type PythonEncode() =
     interface IEncode with
@@ -40,4 +41,4 @@ let main args =
             Decoders.tests runner
             Encoders.tests runner
         ]
-    |> Pyxpecto.runTests
+    |> Pyxpecto.runTests [||]

--- a/tests/Thoth.Json.Tests.Python/packages.lock.json
+++ b/tests/Thoth.Json.Tests.Python/packages.lock.json
@@ -22,9 +22,9 @@
       },
       "Fable.Pyxpecto": {
         "type": "Direct",
-        "requested": "[0.3.0, )",
-        "resolved": "0.3.0",
-        "contentHash": "IrlYxeR9IdXy6I4xn12FWnMsCOyi67ib51i456Gf58Dxq+k/oM7RzMxcd1aKf7cSbzOiknxzQlGWK7h/YfKIDw==",
+        "requested": "[1.0.1, )",
+        "resolved": "1.0.1",
+        "contentHash": "Yx2kfGLin4UN8Wmo/BEnr6AY5IoOs0ylf/ozoFphUnkUExKdLAaKRtXNY6Jvyqb9vSVUmFq+7/899LErlOTFxQ==",
         "dependencies": {
           "FSharp.Core": "5.0.0",
           "Fable.Core": "4.1.0",

--- a/tests/Thoth.Json.Tests.Python/packages.lock.json
+++ b/tests/Thoth.Json.Tests.Python/packages.lock.json
@@ -2,6 +2,18 @@
   "version": 2,
   "dependencies": {
     "net6.0": {
+      "DotNet.ReproducibleBuilds": {
+        "type": "Direct",
+        "requested": "[1.1.1, )",
+        "resolved": "1.1.1",
+        "contentHash": "+H2t/t34h6mhEoUvHi8yGXyuZ2GjSovcGYehJrS2MDm2XgmPfZL2Sdxg+uL2lKgZ4M6tTwKHIlxOob2bgh0NRQ==",
+        "dependencies": {
+          "Microsoft.SourceLink.AzureRepos.Git": "1.1.1",
+          "Microsoft.SourceLink.Bitbucket.Git": "1.1.1",
+          "Microsoft.SourceLink.GitHub": "1.1.1",
+          "Microsoft.SourceLink.GitLab": "1.1.1"
+        }
+      },
       "Fable.Core": {
         "type": "Direct",
         "requested": "[4.1.0, )",
@@ -24,6 +36,52 @@
         "requested": "[5.0.0, )",
         "resolved": "5.0.0",
         "contentHash": "iHoYXA0VaSQUONGENB1aVafjDDZDZpwu39MtaRCTrmwFW/cTcK0b2yKNVYneFHJMc3ChtsSoM9lNtJ1dYXkHfA=="
+      },
+      "Microsoft.Build.Tasks.Git": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "AT3HlgTjsqHnWpBHSNeR0KxbLZD7bztlZVj7I8vgeYG9SYqbeFGh0TM/KVtC6fg53nrWHl3VfZFvb5BiQFcY6Q=="
+      },
+      "Microsoft.SourceLink.AzureRepos.Git": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "qB5urvw9LO2bG3eVAkuL+2ughxz2rR7aYgm2iyrB8Rlk9cp2ndvGRCvehk3rNIhRuNtQaeKwctOl1KvWiklv5w==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "1.1.1",
+          "Microsoft.SourceLink.Common": "1.1.1"
+        }
+      },
+      "Microsoft.SourceLink.Bitbucket.Git": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "cDzxXwlyWpLWaH0em4Idj0H3AmVo3L/6xRXKssYemx+7W52iNskj/SQ4FOmfCb8YQt39otTDNMveCZzYtMoucQ==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "1.1.1",
+          "Microsoft.SourceLink.Common": "1.1.1"
+        }
+      },
+      "Microsoft.SourceLink.Common": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "WMcGpWKrmJmzrNeuaEb23bEMnbtR/vLmvZtkAP5qWu7vQsY59GqfRJd65sFpBszbd2k/bQ8cs8eWawQKAabkVg=="
+      },
+      "Microsoft.SourceLink.GitHub": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "IaJGnOv/M7UQjRJks7B6p7pbPnOwisYGOIzqCz5ilGFTApZ3ktOR+6zJ12ZRPInulBmdAf1SrGdDG2MU8g6XTw==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "1.1.1",
+          "Microsoft.SourceLink.Common": "1.1.1"
+        }
+      },
+      "Microsoft.SourceLink.GitLab": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "tvsg47DDLqqedlPeYVE2lmiTpND8F0hkrealQ5hYltSmvruy/Gr5nHAKSsjyw5L3NeM/HLMI5ORv7on/M4qyZw==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "1.1.1",
+          "Microsoft.SourceLink.Common": "1.1.1"
+        }
       },
       "thoth.json.core": {
         "type": "Project",

--- a/tests/Thoth.Json.Tests/Encoders.fs
+++ b/tests/Thoth.Json.Tests/Encoders.fs
@@ -33,7 +33,7 @@ let tests (runner: TestRunner<_, _>) =
                         let actual =
                             Encode.string "maxime" |> runner.Encode.toString 0
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "a string with new line works"
                     <| fun _ ->
@@ -42,7 +42,7 @@ let tests (runner: TestRunner<_, _>) =
                         let actual =
                             Encode.string "a\nb" |> runner.Encode.toString 4
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "a string with new line character works"
                     <| fun _ ->
@@ -51,7 +51,7 @@ let tests (runner: TestRunner<_, _>) =
                         let actual =
                             Encode.string "a\\nb" |> runner.Encode.toString 4
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "a string with tab works"
                     <| fun _ ->
@@ -60,7 +60,7 @@ let tests (runner: TestRunner<_, _>) =
                         let actual =
                             Encode.string "a\tb" |> runner.Encode.toString 4
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "a string with tab character works"
                     <| fun _ ->
@@ -69,20 +69,20 @@ let tests (runner: TestRunner<_, _>) =
                         let actual =
                             Encode.string "a\\tb" |> runner.Encode.toString 4
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "a char works"
                     <| fun _ ->
                         let expected = "\"a\""
                         let actual = Encode.char 'a' |> runner.Encode.toString 0
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "an int works"
                     <| fun _ ->
                         let expected = "1"
                         let actual = Encode.int 1 |> runner.Encode.toString 0
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "a float works"
                     <| fun _ ->
@@ -91,7 +91,7 @@ let tests (runner: TestRunner<_, _>) =
                         let actual =
                             Encode.float 1.2 |> runner.Encode.toString 0
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "an array works"
                     <| fun _ ->
@@ -105,7 +105,7 @@ let tests (runner: TestRunner<_, _>) =
                                 |]
                             |> runner.Encode.toString 0
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "a list works"
                     <| fun _ ->
@@ -119,7 +119,7 @@ let tests (runner: TestRunner<_, _>) =
                                 ]
                             |> runner.Encode.toString 0
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "a bool works"
                     <| fun _ ->
@@ -128,19 +128,19 @@ let tests (runner: TestRunner<_, _>) =
                         let actual =
                             Encode.bool false |> runner.Encode.toString 0
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "a null works"
                     <| fun _ ->
                         let expected = "null"
                         let actual = Encode.nil |> runner.Encode.toString 0
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "unit works"
                     <| fun _ ->
                         let expected = "null"
                         let actual = Encode.unit () |> runner.Encode.toString 0
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "an object works"
                     <| fun _ ->
@@ -154,7 +154,7 @@ let tests (runner: TestRunner<_, _>) =
                                 ]
                             |> runner.Encode.toString 0
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "a dict works"
                     <| fun _ ->
@@ -170,7 +170,7 @@ let tests (runner: TestRunner<_, _>) =
                             |> Encode.dict
                             |> runner.Encode.toString 0
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "a map works"
                     <| fun _ ->
@@ -186,7 +186,7 @@ let tests (runner: TestRunner<_, _>) =
                             |> Encode.map Encode.string Encode.int
                             |> runner.Encode.toString 0
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "a bigint works"
                     <| fun _ ->
@@ -195,7 +195,7 @@ let tests (runner: TestRunner<_, _>) =
                         let actual =
                             Encode.bigint 12I |> runner.Encode.toString 0
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "a datetime works"
                     <| fun _ ->
@@ -215,7 +215,7 @@ let tests (runner: TestRunner<_, _>) =
                             |> Encode.datetime
                             |> runner.Encode.toString 0
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "a datetimeOffset works"
                     <| fun _ ->
@@ -238,7 +238,7 @@ let tests (runner: TestRunner<_, _>) =
                             |> Encode.datetimeOffset
                             |> runner.Encode.toString 0
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "a timeSpan works"
                     <| fun _ ->
@@ -249,9 +249,9 @@ let tests (runner: TestRunner<_, _>) =
                             |> Encode.timespan
                             |> runner.Encode.toString 0
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
-                    runner.testCase "a decimal works"
+                    runner.ftestCase "a decimal works"
                     <| fun _ ->
                         let expected = "\"0.7833\""
 
@@ -260,7 +260,7 @@ let tests (runner: TestRunner<_, _>) =
                             |> Encode.decimal
                             |> runner.Encode.toString 0
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "a guid works"
                     <| fun _ ->
@@ -272,7 +272,7 @@ let tests (runner: TestRunner<_, _>) =
                             |> Encode.guid
                             |> runner.Encode.toString 0
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "an byte works"
                     <| fun _ ->
@@ -281,7 +281,7 @@ let tests (runner: TestRunner<_, _>) =
                         let actual =
                             99uy |> Encode.byte |> runner.Encode.toString 0
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "an sbyte works"
                     <| fun _ ->
@@ -290,7 +290,7 @@ let tests (runner: TestRunner<_, _>) =
                         let actual =
                             99y |> Encode.sbyte |> runner.Encode.toString 0
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "an int16 works"
                     <| fun _ ->
@@ -299,7 +299,7 @@ let tests (runner: TestRunner<_, _>) =
                         let actual =
                             99s |> Encode.int16 |> runner.Encode.toString 0
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "an uint16 works"
                     <| fun _ ->
@@ -308,7 +308,7 @@ let tests (runner: TestRunner<_, _>) =
                         let actual =
                             99us |> Encode.uint16 |> runner.Encode.toString 0
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "an int64 works"
                     <| fun _ ->
@@ -317,7 +317,7 @@ let tests (runner: TestRunner<_, _>) =
                         let actual =
                             7923209L |> Encode.int64 |> runner.Encode.toString 0
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "an uint64 works"
                     <| fun _ ->
@@ -328,7 +328,7 @@ let tests (runner: TestRunner<_, _>) =
                             |> Encode.uint64
                             |> runner.Encode.toString 0
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "an enum<sbyte> works"
                     <| fun _ ->
@@ -339,7 +339,7 @@ let tests (runner: TestRunner<_, _>) =
                                 0
                                 (Encode.Enum.sbyte Enum_Int8.NinetyNine)
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "an enum<byte> works"
                     <| fun _ ->
@@ -350,7 +350,7 @@ let tests (runner: TestRunner<_, _>) =
                                 0
                                 (Encode.Enum.byte Enum_UInt8.NinetyNine)
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "an enum<int> works"
                     <| fun _ ->
@@ -361,7 +361,7 @@ let tests (runner: TestRunner<_, _>) =
                                 0
                                 (Encode.Enum.int Enum_Int.One)
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "an enum<uint32> works"
                     <| fun _ ->
@@ -372,7 +372,7 @@ let tests (runner: TestRunner<_, _>) =
                                 0
                                 (Encode.Enum.uint32 Enum_UInt32.NinetyNine)
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "an enum<int16> works"
                     <| fun _ ->
@@ -383,7 +383,7 @@ let tests (runner: TestRunner<_, _>) =
                                 0
                                 (Encode.Enum.int16 Enum_Int16.NinetyNine)
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "an enum<uint16> works"
                     <| fun _ ->
@@ -394,7 +394,7 @@ let tests (runner: TestRunner<_, _>) =
                                 0
                                 (Encode.Enum.uint16 Enum_UInt16.NinetyNine)
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "a tuple2 works"
                     <| fun _ ->
@@ -404,7 +404,7 @@ let tests (runner: TestRunner<_, _>) =
                             Encode.tuple2 Encode.int Encode.string (1, "maxime")
                             |> runner.Encode.toString 0
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "a tuple3 works"
                     <| fun _ ->
@@ -418,7 +418,7 @@ let tests (runner: TestRunner<_, _>) =
                                 (1, "maxime", 2.5)
                             |> runner.Encode.toString 0
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "a tuple4 works"
                     <| fun _ ->
@@ -438,7 +438,7 @@ let tests (runner: TestRunner<_, _>) =
                                  })
                             |> runner.Encode.toString 0
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "a tuple5 works"
                     <| fun _ ->
@@ -481,7 +481,7 @@ let tests (runner: TestRunner<_, _>) =
                                  ))
                             |> runner.Encode.toString 0
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "a tuple6 works"
                     <| fun _ ->
@@ -506,7 +506,7 @@ let tests (runner: TestRunner<_, _>) =
                                  null)
                             |> runner.Encode.toString 0
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "a tuple7 works"
                     <| fun _ ->
@@ -533,7 +533,7 @@ let tests (runner: TestRunner<_, _>) =
                                  true)
                             |> runner.Encode.toString 0
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "a tuple8 works"
                     <| fun _ ->
@@ -562,7 +562,7 @@ let tests (runner: TestRunner<_, _>) =
                                  98)
                             |> runner.Encode.toString 0
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "using pretty space works"
                     <| fun _ ->
@@ -577,7 +577,7 @@ let tests (runner: TestRunner<_, _>) =
                                 ]
                             |> runner.Encode.toString 4
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "complex structure works"
                     <| fun _ ->
@@ -598,7 +598,7 @@ let tests (runner: TestRunner<_, _>) =
                                 ]
                             |> runner.Encode.toString 4
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "option with a value `Some ...` works"
                     <| fun _ ->
@@ -613,7 +613,7 @@ let tests (runner: TestRunner<_, _>) =
                                 ]
                             |> runner.Encode.toString 0
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                     runner.testCase "option without a value `None` works"
                     <| fun _ ->
@@ -628,7 +628,7 @@ let tests (runner: TestRunner<_, _>) =
                                 ]
                             |> runner.Encode.toString 0
 
-                        runner.equal expected actual
+                        runner.equal actual expected
 
                 //             runner.testCase "by default, we keep the case defined in type" <| fun _ ->
                 //                 let expected =
@@ -640,14 +640,14 @@ let tests (runner: TestRunner<_, _>) =
                 //                       followers = 33 }
 
                 //                 let actual = Encode.Auto.toString(0, value)
-                //                 runner.equal expected actual
+                //                 runner.equal actual expected
 
                 //             runner.testCase "force_snake_case works" <| fun _ ->
                 //                 let expected =
                 //                     """{"one":1,"two_part":2,"three_part_field":3}"""
                 //                 let value = { One = 1; TwoPart = 2; ThreePartField = 3 }
                 //                 let actual = Encode.Auto.toString(0, value, SnakeCase)
-                //                 runner.equal expected actual
+                //                 runner.equal actual expected
 
                 //             runner.testCase "forceCamelCase works" <| fun _ ->
                 //                 let expected =
@@ -659,7 +659,7 @@ let tests (runner: TestRunner<_, _>) =
                 //                       followers = 33 }
 
                 //                 let actual = Encode.Auto.toString(0, value, CamelCase)
-                //                 runner.equal expected actual
+                //                 runner.equal actual expected
 
                 //             runner.testCase "Encode.Auto.generateEncoder works" <| fun _ ->
                 //                 let value =
@@ -693,7 +693,7 @@ let tests (runner: TestRunner<_, _>) =
                 //                 let expected = """{"a":5,"b":"bar","c":[[false,3],[true,5],[false,10]],"d":[["Foo",14],null],"e":{"ah":{"a":-1.5,"b":0},"oh":{"a":2,"b":2}},"f":"2018-11-28T11:10:29Z","g":[{"a":-1.5,"b":0},{"a":2,"b":2}],"h":"00:00:05","i":120,"j":120,"k":250,"l":250,"m":99,"n":"99","o":"999","r":[[{"a":-2.5,"b":22.1},"value 2"],[{"a":1,"b":2},"value 1"]],"s":"z"}"""
                 //                 // Don't fail because of non-meaningful decimal digits ("2" vs "2.0")
                 //                 let actual = System.Text.RegularExpressions.Regex.Replace(actual, @"\.0+(?!\d)", "")
-                //                 runner.equal expected actual
+                //                 runner.equal actual expected
 
                 //             runner.testCase "Encode.Auto.generateEncoderCached works" <| fun _ ->
                 //                 let value =
@@ -730,15 +730,15 @@ let tests (runner: TestRunner<_, _>) =
                 //                 // Don't fail because of non-meaningful decimal digits ("2" vs "2.0")
                 //                 let actual1 = System.Text.RegularExpressions.Regex.Replace(actual1, @"\.0+(?!\d)", "")
                 //                 let actual2 = System.Text.RegularExpressions.Regex.Replace(actual2, @"\.0+(?!\d)", "")
-                //                 runner.equal expected actual1
-                //                 runner.equal expected actual2
+                //                 runner.equal actual expected 1
+                //                 runner.equal actual expected 2
                 //                 runner.equal actual1 actual2
 
                 //             runner.testCase "Encode.Auto.toString emit null field if setted for" <| fun _ ->
                 //                 let value = { fieldA = null }
                 //                 let expected = """{"fieldA":null}"""
                 //                 let actual = Encode.Auto.toString(0, value, skipNullField = false)
-                //                 runner.equal expected actual
+                //                 runner.equal actual expected
 
                 //             runner.testCase "Encode.Auto.toString works with bigint extra" <| fun _ ->
                 //                 let extra =
@@ -747,7 +747,7 @@ let tests (runner: TestRunner<_, _>) =
                 //                 let expected = """{"bigintField":"9999999999999999999999"}"""
                 //                 let value = { bigintField = 9999999999999999999999I }
                 //                 let actual = Encode.Auto.toString(0, value, extra=extra)
-                //                 runner.equal expected actual
+                //                 runner.equal actual expected
 
                 //             runner.testCase "Encode.Auto.toString works with custom extra" <| fun _ ->
                 //                 let extra =
@@ -756,7 +756,7 @@ let tests (runner: TestRunner<_, _>) =
                 //                 let expected = """{"ParentField":"bumbabon"}"""
                 //                 let value = { ParentField = { ChildField = "bumbabon" } }
                 //                 let actual = Encode.Auto.toString(0, value, extra=extra)
-                //                 runner.equal expected actual
+                //                 runner.equal actual expected
 
                 //             runner.testCase "Encode.Auto.toString serializes maps with Guid keys as JSON objects" <| fun _ ->
                 //                 let m = Map [Guid.NewGuid(), 1; Guid.NewGuid(), 2]
@@ -810,33 +810,33 @@ let tests (runner: TestRunner<_, _>) =
                 //             runner.testCase "Encode.Auto.toString works with [<StringEnum>]" <| fun _ ->
                 //                 let expected = "\"firstPerson\""
                 //                 let actual = Encode.Auto.toString(0, Camera.FirstPerson)
-                //                 runner.equal expected actual
+                //                 runner.equal actual expected
 
                 //             runner.testCase "Encode.Auto.toString works with [<StringEnum(CaseRules.LowerFirst)>]" <| fun _ ->
                 //                 let expected = "\"react\""
                 //                 let actual = Encode.Auto.toString(0, Framework.React)
-                //                 runner.equal expected actual
+                //                 runner.equal actual expected
 
                 //             runner.testCase "Encode.Auto.toString works with [<StringEnum(CaseRules.None)>]" <| fun _ ->
                 //                 let expected = "\"Fsharp\""
                 //                 let actual = Encode.Auto.toString(0, Language.Fsharp)
-                //                 runner.equal expected actual
+                //                 runner.equal actual expected
 
                 //             runner.testCase "Encode.Auto.toString works with [<StringEnum>] + [<CompiledName>]" <| fun _ ->
                 //                 let expected = "\"C#\""
                 //                 let actual = Encode.Auto.toString(0, Language.Csharp)
-                //                 runner.equal expected actual
+                //                 runner.equal actual expected
                 //             #endif
 
                 //             runner.testCase "Encode.Auto.toString works with normal Enums" <| fun _ ->
                 //                 let expected = "2"
                 //                 let actual = Encode.Auto.toString(0, Enum_Int.Two)
-                //                 runner.equal expected actual
+                //                 runner.equal actual expected
 
                 //             runner.testCase "Encode.Auto.toString works with System.DayOfWeek" <| fun _ ->
                 //                 let expected = "2"
                 //                 let actual = Encode.Auto.toString(0, DayOfWeek.Tuesday)
-                //                 runner.equal expected actual
+                //                 runner.equal actual expected
 
                 //             runner.testCase "Encode.Auto.toString generate `null` if skipNullField is true and the optional field value of type classes is None" <| fun _ ->
                 //                 let value =
@@ -848,7 +848,7 @@ let tests (runner: TestRunner<_, _>) =
                 //                 let actual = Encode.Auto.toString(0, value, caseStrategy = CamelCase, skipNullField = false)
                 //                 let expected =
                 //                     """{"maybeClass":null,"must":"must value"}"""
-                //                 runner.equal expected actual
+                //                 runner.equal actual expected
 
                 //             runner.testCase "Encode.Auto.toString doesn't generate the optional field of type classe if it's value is None" <| fun _ ->
                 //                 let value =
@@ -860,7 +860,7 @@ let tests (runner: TestRunner<_, _>) =
                 //                 let actual = Encode.Auto.toString(0, value, caseStrategy = CamelCase)
                 //                 let expected =
                 //                     """{"must":"must value"}"""
-                //                 runner.equal expected actual
+                //                 runner.equal actual expected
 
                 //             runner.testCase "Encode.Auto.generateEncoder throws for field using a non optional class" <| fun _ ->
                 //                 let expected = """Cannot generate auto encoder for Tests.Types.BaseClass. Please pass an extra encoder.
@@ -901,19 +901,19 @@ let tests (runner: TestRunner<_, _>) =
                 //                 let expected =
                 //                     """{"type":"customInt","value":42}"""
 
-                //                 runner.equal expected actual
+                //                 runner.equal actual expected
 
                 //             runner.testCase "Encode.Auto.toString(value, ...) is equivalent to Encode.Auto.toString(0, value, ...)" <| fun _ ->
                 //                 let expected = Encode.Auto.toString(0, {| Name = "Maxime" |})
                 //                 let actual = Encode.Auto.toString({| Name = "Maxime" |})
-                //                 runner.equal expected actual
+                //                 runner.equal actual expected
 
                 (*
 #if NETFRAMEWORK
             runner.testCase "Encode.Auto.toString works with char based Enums" <| fun _ ->
                 let expected = ((int) 'A').ToString()  // "65"
                 let actual = Encode.Auto.toString(0, CharEnum.A)
-                runner.equal expected actual
+                runner.equal actual expected 
 #endif
     *)
                 ]

--- a/tests/Thoth.Json.Tests/Encoders.fs
+++ b/tests/Thoth.Json.Tests/Encoders.fs
@@ -251,7 +251,7 @@ let tests (runner: TestRunner<_, _>) =
 
                         runner.equal actual expected
 
-                    runner.ftestCase "a decimal works"
+                    runner.testCase "a decimal works"
                     <| fun _ ->
                         let expected = "\"0.7833\""
 

--- a/tests/Thoth.Json.Tests/Util.fs
+++ b/tests/Thoth.Json.Tests/Util.fs
@@ -34,6 +34,7 @@ type IDecode =
 type TestRunner<'Test, 'JsonValue>() =
     abstract testList: (string -> 'Test list -> 'Test) with get
     abstract testCase: (string -> (unit -> unit) -> 'Test) with get
-    abstract equal<'a when 'a: equality> : 'a -> 'a -> unit
+    abstract ftestCase: (string -> (unit -> unit) -> 'Test) with get
+    abstract equal<'a when 'a: equality> : actual: 'a -> expected: 'a -> unit
     abstract Encode: IEncode with get
     abstract Decode: IDecode with get

--- a/tests/Thoth.Json.Tests/packages.lock.json
+++ b/tests/Thoth.Json.Tests/packages.lock.json
@@ -2,6 +2,18 @@
   "version": 2,
   "dependencies": {
     ".NETStandard,Version=v2.0": {
+      "DotNet.ReproducibleBuilds": {
+        "type": "Direct",
+        "requested": "[1.1.1, )",
+        "resolved": "1.1.1",
+        "contentHash": "+H2t/t34h6mhEoUvHi8yGXyuZ2GjSovcGYehJrS2MDm2XgmPfZL2Sdxg+uL2lKgZ4M6tTwKHIlxOob2bgh0NRQ==",
+        "dependencies": {
+          "Microsoft.SourceLink.AzureRepos.Git": "1.1.1",
+          "Microsoft.SourceLink.Bitbucket.Git": "1.1.1",
+          "Microsoft.SourceLink.GitHub": "1.1.1",
+          "Microsoft.SourceLink.GitLab": "1.1.1"
+        }
+      },
       "Fable.Core": {
         "type": "Direct",
         "requested": "[4.1.0, )",
@@ -23,10 +35,56 @@
           "Microsoft.NETCore.Platforms": "1.1.0"
         }
       },
+      "Microsoft.Build.Tasks.Git": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "AT3HlgTjsqHnWpBHSNeR0KxbLZD7bztlZVj7I8vgeYG9SYqbeFGh0TM/KVtC6fg53nrWHl3VfZFvb5BiQFcY6Q=="
+      },
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
         "resolved": "1.1.0",
         "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
+      },
+      "Microsoft.SourceLink.AzureRepos.Git": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "qB5urvw9LO2bG3eVAkuL+2ughxz2rR7aYgm2iyrB8Rlk9cp2ndvGRCvehk3rNIhRuNtQaeKwctOl1KvWiklv5w==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "1.1.1",
+          "Microsoft.SourceLink.Common": "1.1.1"
+        }
+      },
+      "Microsoft.SourceLink.Bitbucket.Git": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "cDzxXwlyWpLWaH0em4Idj0H3AmVo3L/6xRXKssYemx+7W52iNskj/SQ4FOmfCb8YQt39otTDNMveCZzYtMoucQ==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "1.1.1",
+          "Microsoft.SourceLink.Common": "1.1.1"
+        }
+      },
+      "Microsoft.SourceLink.Common": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "WMcGpWKrmJmzrNeuaEb23bEMnbtR/vLmvZtkAP5qWu7vQsY59GqfRJd65sFpBszbd2k/bQ8cs8eWawQKAabkVg=="
+      },
+      "Microsoft.SourceLink.GitHub": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "IaJGnOv/M7UQjRJks7B6p7pbPnOwisYGOIzqCz5ilGFTApZ3ktOR+6zJ12ZRPInulBmdAf1SrGdDG2MU8g6XTw==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "1.1.1",
+          "Microsoft.SourceLink.Common": "1.1.1"
+        }
+      },
+      "Microsoft.SourceLink.GitLab": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "tvsg47DDLqqedlPeYVE2lmiTpND8F0hkrealQ5hYltSmvruy/Gr5nHAKSsjyw5L3NeM/HLMI5ORv7on/M4qyZw==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "1.1.1",
+          "Microsoft.SourceLink.Common": "1.1.1"
+        }
       },
       "thoth.json.core": {
         "type": "Project",


### PR DESCRIPTION
As requested i ran all tests on my windows machine and only newtonsoft tests were failing. Any decimal was written to string with `,` as separator. Not sure if this was a windows or computer settings issue. I added a very dirty fix for this.

While checking for the bug, i added a ftestCase option to the runner and fixed some orders on the tests aligning them with test message output.