### PR TITLE
experiment/issue-175-encoders-without-json-du

### DIFF
--- a/packages/Thoth.Json.Core/CHANGELOG.md
+++ b/packages/Thoth.Json.Core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+* Rework encoder API to not need a custom DU ([GH-188](https://github.com/thoth-org/Thoth.Json/pull/188/))
+
 ## 0.2.1 - 2023-12-12
 
 ### Fixed

--- a/packages/Thoth.Json.Core/Encode.fs
+++ b/packages/Thoth.Json.Core/Encode.fs
@@ -9,19 +9,19 @@ module Encode =
 
     let inline string value =
         { new IEncodable with
-            member this.Encode(helpers) = helpers.encodeString (value)
+            member _.Encode(helpers) = helpers.encodeString value
         }
 
     let inline char value =
         { new IEncodable with
-            member this.Encode(helpers) = helpers.encodeChar (value)
+            member _.Encode(helpers) = helpers.encodeChar value
         }
 
     let inline guid value = value.ToString() |> string
 
     let inline float value =
         { new IEncodable with
-            member this.Encode(helpers) = helpers.encodeDecimalNumber (value)
+            member _.Encode(helpers) = helpers.encodeDecimalNumber value
         }
 
     let float32 (value: float32) = float (Operators.float value)
@@ -31,17 +31,17 @@ module Encode =
 
     let inline nil<'T> =
         { new IEncodable with
-            member this.Encode(helpers) = helpers.encodeNull ()
+            member _.Encode(helpers) = helpers.encodeNull ()
         }
 
     let inline bool value =
         { new IEncodable with
-            member this.Encode(helpers) = helpers.encodeBool (value)
+            member _.Encode(helpers) = helpers.encodeBool value
         }
 
     let inline object (values: seq<string * IEncodable>) =
         { new IEncodable with
-            member this.Encode(helpers) =
+            member _.Encode(helpers) =
                 let o = helpers.createEmptyObject ()
 
                 for k, v in values do
@@ -53,7 +53,7 @@ module Encode =
 
     let inline array (values: IEncodable array) =
         { new IEncodable with
-            member this.Encode(helpers) =
+            member _.Encode(helpers) =
                 values
                 |> Array.map (fun v -> v.Encode(helpers))
                 |> helpers.encodeArray
@@ -61,7 +61,7 @@ module Encode =
 
     let list (values: IEncodable list) =
         { new IEncodable with
-            member this.Encode(helpers) =
+            member _.Encode(helpers) =
                 values
                 |> List.map (fun v -> v.Encode(helpers))
                 |> helpers.encodeList
@@ -69,7 +69,7 @@ module Encode =
 
     let seq (values: IEncodable seq) =
         { new IEncodable with
-            member this.Encode(helpers) =
+            member _.Encode(helpers) =
                 values
                 |> Seq.map (fun v -> v.Encode(helpers))
                 |> helpers.encodeSeq
@@ -90,37 +90,37 @@ module Encode =
 
     let inline sbyte (value: sbyte) =
         { new IEncodable with
-            member this.Encode(helpers) =
+            member _.Encode(helpers) =
                 helpers.encodeIntegralNumber (uint32 value)
         }
 
     let inline byte (value: byte) =
         { new IEncodable with
-            member this.Encode(helpers) =
+            member _.Encode(helpers) =
                 helpers.encodeIntegralNumber (uint32 value)
         }
 
     let inline int16 (value: int16) =
         { new IEncodable with
-            member this.Encode(helpers) =
+            member _.Encode(helpers) =
                 helpers.encodeIntegralNumber (uint32 value)
         }
 
     let inline uint16 (value: uint16) =
         { new IEncodable with
-            member this.Encode(helpers) =
+            member _.Encode(helpers) =
                 helpers.encodeIntegralNumber (uint32 value)
         }
 
     let inline int (value: int) =
         { new IEncodable with
-            member this.Encode(helpers) =
+            member _.Encode(helpers) =
                 helpers.encodeIntegralNumber (uint32 value)
         }
 
     let inline uint32 (value: uint32) =
         { new IEncodable with
-            member this.Encode(helpers) = helpers.encodeIntegralNumber (value)
+            member _.Encode(helpers) = helpers.encodeIntegralNumber (value)
         }
 
     let inline int64 (value: int64) =

--- a/packages/Thoth.Json.Core/Encode.fs
+++ b/packages/Thoth.Json.Core/Encode.fs
@@ -8,84 +8,71 @@ open System
 module Encode =
 
     let inline string value =
-        {
-            new IEncodable with
-                member this.Encode(helpers) =
-                    helpers.encodeString(value)
+        { new IEncodable with
+            member this.Encode(helpers) = helpers.encodeString (value)
         }
 
     let inline char value =
-        {
-            new IEncodable with
-                member this.Encode(helpers) =
-                    helpers.encodeChar(value)
+        { new IEncodable with
+            member this.Encode(helpers) = helpers.encodeChar (value)
         }
 
     let inline guid value = value.ToString() |> string
 
     let inline float value =
-        {
-            new IEncodable with
-                member this.Encode(helpers) =
-                    helpers.encodeDecimalNumber(value)
+        { new IEncodable with
+            member this.Encode(helpers) = helpers.encodeDecimalNumber (value)
         }
 
-    let float32 (value: float32) =
-        float (Operators.float value)
+    let float32 (value: float32) = float (Operators.float value)
 
     let inline decimal (value: decimal) =
         value.ToString(CultureInfo.InvariantCulture) |> string
 
     let inline nil<'T> =
-        {
-            new IEncodable with
-                member this.Encode(helpers) =
-                    helpers.encodeNull()
+        { new IEncodable with
+            member this.Encode(helpers) = helpers.encodeNull ()
         }
 
     let inline bool value =
-        {
-            new IEncodable with
-                member this.Encode(helpers) =
-                    helpers.encodeBool(value)
+        { new IEncodable with
+            member this.Encode(helpers) = helpers.encodeBool (value)
         }
 
-    let inline object (values : seq<string * IEncodable>) =
-        {
-            new IEncodable with
-                member this.Encode(helpers) =
-                    let o = helpers.createEmptyObject()
-                    for k, v in values do
-                        let ve = v.Encode(helpers)
-                        helpers.setPropertyOnObject(o, k, ve)
-                    o
+    let inline object (values: seq<string * IEncodable>) =
+        { new IEncodable with
+            member this.Encode(helpers) =
+                let o = helpers.createEmptyObject ()
+
+                for k, v in values do
+                    let ve = v.Encode(helpers)
+                    helpers.setPropertyOnObject (o, k, ve)
+
+                o
         }
 
-    let inline array (values : IEncodable array) =
-        {
-            new IEncodable with
-                member this.Encode(helpers) =
-                    values
-                    |> Array.map (fun v -> v.Encode(helpers))
-                    |> helpers.encodeArray
+    let inline array (values: IEncodable array) =
+        { new IEncodable with
+            member this.Encode(helpers) =
+                values
+                |> Array.map (fun v -> v.Encode(helpers))
+                |> helpers.encodeArray
         }
 
-    let list (values : IEncodable list) =
-        {
-            new IEncodable with
-                member this.Encode(helpers) =
-                    values
-                    |> List.map (fun v -> v.Encode(helpers))
-                    |> helpers.encodeList
+    let list (values: IEncodable list) =
+        { new IEncodable with
+            member this.Encode(helpers) =
+                values
+                |> List.map (fun v -> v.Encode(helpers))
+                |> helpers.encodeList
         }
 
-    let seq (values : IEncodable seq) =
-        {
-            new IEncodable with
-                member this.Encode(helpers) =
-                    values
-                    |> Seq.map (fun v -> v.Encode(helpers))
-                    |> helpers.encodeSeq
+    let seq (values: IEncodable seq) =
+        { new IEncodable with
+            member this.Encode(helpers) =
+                values
+                |> Seq.map (fun v -> v.Encode(helpers))
+                |> helpers.encodeSeq
         }
 
     let dict (values: Map<string, IEncodable>) : IEncodable =
@@ -102,45 +89,38 @@ module Encode =
         value.ToString("O", CultureInfo.InvariantCulture) |> string
 
     let inline sbyte (value: sbyte) =
-        {
-            new IEncodable with
-                member this.Encode(helpers) =
-                    helpers.encodeIntegralNumber(uint32 value)
+        { new IEncodable with
+            member this.Encode(helpers) =
+                helpers.encodeIntegralNumber (uint32 value)
         }
 
     let inline byte (value: byte) =
-        {
-            new IEncodable with
-                member this.Encode(helpers) =
-                    helpers.encodeIntegralNumber(uint32 value)
+        { new IEncodable with
+            member this.Encode(helpers) =
+                helpers.encodeIntegralNumber (uint32 value)
         }
 
     let inline int16 (value: int16) =
-        {
-            new IEncodable with
-                member this.Encode(helpers) =
-                    helpers.encodeIntegralNumber(uint32 value)
+        { new IEncodable with
+            member this.Encode(helpers) =
+                helpers.encodeIntegralNumber (uint32 value)
         }
 
     let inline uint16 (value: uint16) =
-        {
-            new IEncodable with
-                member this.Encode(helpers) =
-                    helpers.encodeIntegralNumber(uint32 value)
+        { new IEncodable with
+            member this.Encode(helpers) =
+                helpers.encodeIntegralNumber (uint32 value)
         }
 
     let inline int (value: int) =
-        {
-            new IEncodable with
-                member this.Encode(helpers) =
-                    helpers.encodeIntegralNumber(uint32 value)
+        { new IEncodable with
+            member this.Encode(helpers) =
+                helpers.encodeIntegralNumber (uint32 value)
         }
 
     let inline uint32 (value: uint32) =
-        {
-            new IEncodable with
-                member this.Encode(helpers) =
-                    helpers.encodeIntegralNumber(value)
+        { new IEncodable with
+            member this.Encode(helpers) = helpers.encodeIntegralNumber (value)
         }
 
     let inline int64 (value: int64) =
@@ -293,23 +273,38 @@ module Encode =
         let byte<'TEnum when 'TEnum: enum<byte>> (value: 'TEnum) : IEncodable =
             LanguagePrimitives.EnumToValue value |> byte
 
-        let sbyte<'TEnum when 'TEnum: enum<sbyte>> (value: 'TEnum) : IEncodable =
+        let sbyte<'TEnum when 'TEnum: enum<sbyte>>
+            (value: 'TEnum)
+            : IEncodable
+            =
             LanguagePrimitives.EnumToValue value |> sbyte
 
-        let int16<'TEnum when 'TEnum: enum<int16>> (value: 'TEnum) : IEncodable =
+        let int16<'TEnum when 'TEnum: enum<int16>>
+            (value: 'TEnum)
+            : IEncodable
+            =
             LanguagePrimitives.EnumToValue value |> int16
 
-        let uint16<'TEnum when 'TEnum: enum<uint16>> (value: 'TEnum) : IEncodable =
+        let uint16<'TEnum when 'TEnum: enum<uint16>>
+            (value: 'TEnum)
+            : IEncodable
+            =
             LanguagePrimitives.EnumToValue value |> uint16
 
         let int<'TEnum when 'TEnum: enum<int>> (value: 'TEnum) : IEncodable =
             LanguagePrimitives.EnumToValue value |> int
 
-        let uint32<'TEnum when 'TEnum: enum<uint32>> (value: 'TEnum) : IEncodable =
+        let uint32<'TEnum when 'TEnum: enum<uint32>>
+            (value: 'TEnum)
+            : IEncodable
+            =
             LanguagePrimitives.EnumToValue value |> uint32
 
     let option (encoder: Encoder<'a>) =
         Option.map encoder >> Option.defaultWith (fun _ -> nil)
 
-    let rec toJsonValue (helpers: IEncoderHelpers<'JsonValue>) (json: IEncodable) =
+    let inline toJsonValue
+        (helpers: IEncoderHelpers<'JsonValue>)
+        (json: IEncodable)
+        =
         json.Encode(helpers)

--- a/packages/Thoth.Json.Core/Types.fs
+++ b/packages/Thoth.Json.Core/Types.fs
@@ -73,4 +73,9 @@ type Json =
     | IntegralNumber of uint32
     | Unit
 
-type Encoder<'T> = 'T -> Json
+type IEncodable =
+    abstract member Encode<'JsonValue> :
+        helpers: IEncoderHelpers<'JsonValue> ->
+            'JsonValue
+
+type Encoder<'T> = 'T -> IEncodable

--- a/packages/Thoth.Json.JavaScript/CHANGELOG.md
+++ b/packages/Thoth.Json.JavaScript/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+* Rework encoder API to not need a custom DU ([GH-188](https://github.com/thoth-org/Thoth.Json/pull/188/))
+
 ### Added
 
 * `Decode.unsafeFromString`

--- a/packages/Thoth.Json.JavaScript/Encode.fs
+++ b/packages/Thoth.Json.JavaScript/Encode.fs
@@ -27,6 +27,6 @@ module Encode =
             member _.encodeIntegralNumber value = box value
         }
 
-    let toString (space: int) (value: Json) : string =
+    let toString (space: int) (value: IEncodable) : string =
         let json = Encode.toJsonValue helpers value
         JS.JSON.stringify (json, space = space)

--- a/packages/Thoth.Json.Newtonsoft/CHANGELOG.md
+++ b/packages/Thoth.Json.Newtonsoft/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+* Rework encoder API to not need a custom DU ([GH-188](https://github.com/thoth-org/Thoth.Json/pull/188/))
+
 ### Added
 
 * `Decode.unsafeFromString`

--- a/packages/Thoth.Json.Newtonsoft/Encode.fs
+++ b/packages/Thoth.Json.Newtonsoft/Encode.fs
@@ -37,7 +37,7 @@ module Encode =
                 JValue(uint64 value)
         }
 
-    let toString (space: int) (value: Json) : string =
+    let toString (space: int) (value: IEncodable) : string =
         let format =
             if space = 0 then
                 Formatting.None

--- a/packages/Thoth.Json.Python/CHANGELOG.md
+++ b/packages/Thoth.Json.Python/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+* Rework encoder API to not need a custom DU ([GH-188](https://github.com/thoth-org/Thoth.Json/pull/188/))
+
 ## 0.2.0 - 2024-04-03
 
 ### Added

--- a/packages/Thoth.Json.Python/Encode.fs
+++ b/packages/Thoth.Json.Python/Encode.fs
@@ -21,8 +21,12 @@ module Encode =
                 o?(key) <- value
 
             member _.encodeArray values = values
-            member _.encodeList values = JS.Constructors.Array.from values
-            member _.encodeSeq values = JS.Constructors.Array.from values
+
+            member this.encodeList values =
+                values |> List.toArray |> this.encodeArray
+
+            member this.encodeSeq values =
+                values |> Seq.toArray |> this.encodeArray
 
             member _.encodeIntegralNumber value = box value
         }

--- a/packages/Thoth.Json.Python/Encode.fs
+++ b/packages/Thoth.Json.Python/Encode.fs
@@ -27,7 +27,7 @@ module Encode =
             member _.encodeIntegralNumber value = box value
         }
 
-    let toString (space: int) (value: Json) : string =
+    let toString (space: int) (value: IEncodable) : string =
         let json = Encode.toJsonValue helpers value
         // If we pass an indention of 0 to Python's json.dumps, it will
         // insert newlines, between each element instead of compressing

--- a/tests/Thoth.Json.Tests/Util.fs
+++ b/tests/Thoth.Json.Tests/Util.fs
@@ -25,7 +25,7 @@ open Thoth.Json.Core
 //     abstract
 
 type IEncode =
-    abstract toString: int -> Json -> string
+    abstract toString: int -> IEncodable -> string
 
 type IDecode =
     abstract fromString<'T> : Decoder<'T> -> string -> Result<'T, string>


### PR DESCRIPTION
Change Encoder type to return IEncodable, deferring concrete representation of JSON. 

Follows from the discussion here: https://github.com/thoth-org/Thoth.Json/issues/175#issuecomment-2028222260