### PR TITLE
encode-record-functional-api

### DIFF
--- a/build/Test/Newtonsoft.fs
+++ b/build/Test/Newtonsoft.fs
@@ -14,5 +14,5 @@ let handle (args: string list) =
         |> CmdLine.appendRaw "run"
         |> CmdLine.appendPrefix "--project" Workspace.Fsproj.Tests.newtonsoft
         |> CmdLine.toString,
-        workingDirectory = Workspace.ProjectDir.Tests.javascript
+        workingDirectory = Workspace.ProjectDir.Tests.newtonsoft
     )

--- a/packages/Thoth.Json.Core/Encode.fs
+++ b/packages/Thoth.Json.Core/Encode.fs
@@ -216,14 +216,9 @@ module Encode =
         | Json.String value -> helpers.encodeString value
         | Json.IntegralNumber value -> helpers.encodeIntegralNumber value
         | Json.Object values ->
-            let o = helpers.createEmptyObject ()
-
             values
-            |> Seq.iter (fun (k, v) ->
-                helpers.setPropertyOnObject (o, k, toJsonValue helpers v)
-            )
-
-            o
+            |> Seq.map (fun (k, v) -> k, toJsonValue helpers v)
+            |> helpers.encodeObject
         | Json.Char value -> helpers.encodeChar value
         | Json.DecimalNumber value -> helpers.encodeDecimalNumber value
         | Json.Null -> helpers.encodeNull ()

--- a/packages/Thoth.Json.Core/Types.fs
+++ b/packages/Thoth.Json.Core/Types.fs
@@ -25,8 +25,7 @@ type IEncoderHelpers<'JsonValue> =
     abstract encodeDecimalNumber: float -> 'JsonValue
     abstract encodeBool: bool -> 'JsonValue
     abstract encodeNull: unit -> 'JsonValue
-    abstract createEmptyObject: unit -> 'JsonValue
-    abstract setPropertyOnObject: 'JsonValue * string * 'JsonValue -> unit
+    abstract encodeObject: (string * 'JsonValue) seq -> 'JsonValue
     abstract encodeArray: 'JsonValue array -> 'JsonValue
     abstract encodeList: 'JsonValue list -> 'JsonValue
     abstract encodeSeq: 'JsonValue seq -> 'JsonValue

--- a/packages/Thoth.Json.JavaScript/Encode.fs
+++ b/packages/Thoth.Json.JavaScript/Encode.fs
@@ -3,7 +3,6 @@ namespace Thoth.Json.JavaScript
 open Fable.Core
 open Fable.Core.JsInterop
 open Thoth.Json.Core
-open System.Globalization
 
 [<RequireQualifiedAccess>]
 module Encode =
@@ -15,10 +14,14 @@ module Encode =
             member _.encodeDecimalNumber value = box value
             member _.encodeBool value = box value
             member _.encodeNull() = box null
-            member _.createEmptyObject() = obj ()
 
-            member _.setPropertyOnObject(o: obj, key: string, value: obj) =
-                o?(key) <- value
+            member _.encodeObject(values: (string * obj) seq) =
+                let o = obj ()
+
+                for key, value in values do
+                    o?(key) <- value
+
+                o
 
             member _.encodeArray values = JS.Constructors.Array.from values
             member _.encodeList values = JS.Constructors.Array.from values

--- a/packages/Thoth.Json.Newtonsoft/Encode.fs
+++ b/packages/Thoth.Json.Newtonsoft/Encode.fs
@@ -15,16 +15,14 @@ module Encode =
             member _.encodeDecimalNumber value = JValue(value)
             member _.encodeBool value = JValue(value)
             member _.encodeNull() = JValue.CreateNull()
-            member _.createEmptyObject() = JObject()
 
-            member _.setPropertyOnObject
-                (
-                    o: JToken,
-                    key: string,
-                    value: JToken
-                )
-                =
-                o[key] <- value
+            member _.encodeObject values =
+                let o = JObject()
+
+                for key, value in values do
+                    o[key] <- value
+
+                o
 
             member _.encodeArray values = JArray(values)
             member _.encodeList values = JArray(values)

--- a/packages/Thoth.Json.Python/Encode.fs
+++ b/packages/Thoth.Json.Python/Encode.fs
@@ -15,10 +15,14 @@ module Encode =
             member _.encodeDecimalNumber value = box value
             member _.encodeBool value = box value
             member _.encodeNull() = box null
-            member _.createEmptyObject() = emitPyExpr () "{}"
 
-            member _.setPropertyOnObject(o, key: string, value: obj) =
-                o?(key) <- value
+            member _.encodeObject(values) =
+                let o = emitPyExpr () "{}"
+
+                for key, value in values do
+                    o?(key) <- value
+
+                o
 
             member _.encodeArray values = values
             member _.encodeList values = JS.Constructors.Array.from values


### PR DESCRIPTION
Change encode helpers object API to be functional (as in FP)

This is to support a wider variety of JSON backends. 