### PR TITLE
feature/decode-fix

### DIFF
--- a/packages/Thoth.Json.Core/Decode.fs
+++ b/packages/Thoth.Json.Core/Decode.fs
@@ -1434,6 +1434,42 @@ module Decode =
         =
         map Map.ofSeq (array (tuple2 keyDecoder valueDecoder))
 
+    type private FixDecoder<'a>(make: Decoder<'a> -> Decoder<'a>) as this =
+        let self = make this
+
+        interface Decoder<'a> with
+            member this.Decode
+                (helpers: IDecoderHelpers<'JsonValue>, value: 'JsonValue)
+                =
+                self.Decode(helpers, value)
+
+    /// <summary>
+    /// Allow to build a decoder that can call itself
+    /// </summary>
+    /// <example>
+    /// <code lang="fsharp">
+    /// type Tree =
+    ///     | Empty
+    ///     | Branch of Tree * int * Tree
+    ///
+    /// module Tree =
+    ///
+    ///     let decode =
+    ///         Decode.fix
+    ///             (fun self ->
+    ///                 Decode.oneOf
+    ///                     [
+    ///                         Decode.unit
+    ///                             |> Decode.map (fun () -> Tree.Empty)
+    ///
+    ///                         Decode.tuple3 self Decode.int self
+    ///                             |> Decode.map Tree.Branch
+    ///                     ])
+    /// </code>
+    /// </example>
+    let fix (make: Decoder<'a> -> Decoder<'a>) : Decoder<'a> =
+        FixDecoder<'a>(make)
+
 ////////////
 // Enum ///
 /////////

--- a/tests/Thoth.Json.Tests/Decoders.fs
+++ b/tests/Thoth.Json.Tests/Decoders.fs
@@ -46,6 +46,10 @@ type UnionWithPrivateConstructor =
 
 type UnionWithMultipleFields = | Multi of string * int * float
 
+type Tree<'a> =
+    | Empty
+    | Branch of Tree<'a> * 'a * Tree<'a>
+
 let tests (runner: TestRunner<'DecoderJsonValue, 'EncoderJsonValue>) =
     testList
         "Thoth.Json.Decode"
@@ -2827,6 +2831,41 @@ Expecting an object with a field named `version` but instead got:
                                 ]
 
                         let actual = runner.Decode.fromString decodeAll "{}"
+
+                        equal expected actual
+
+
+                    testCase "fix works"
+                    <| fun _ ->
+                        let expected =
+                            Ok(
+                                Tree.Branch(
+                                    Tree.Empty,
+                                    3,
+                                    Tree.Branch(
+                                        Tree.Branch(Tree.Empty, 5, Tree.Empty),
+                                        4,
+                                        Tree.Empty
+                                    )
+                                )
+                            )
+
+                        let decoder =
+                            Decode.fix (fun self ->
+                                Decode.oneOf
+                                    [
+                                        Decode.unit
+                                        |> Decode.map (fun () -> Tree.Empty)
+
+                                        Decode.tuple3 self Decode.int self
+                                        |> Decode.map Tree.Branch
+                                    ]
+                            )
+
+                        let actual =
+                            runner.Decode.fromString
+                                decoder
+                                "[ null, 3, [ [ null, 5, null ], 4, null ]]"
 
                         equal expected actual
                 ]


### PR DESCRIPTION
This PR adds `Decode.fix`, which is an important combinator for decoding recursive structures. 

It takes a function that, given a reference to itself, builds a decoder. 

```fsharp
val fix : (Decoder<'a> -> Decoder<'a>) -> Decoder<'a>
```

For example, consider this DU:

```fsharp
type Tree =
    | Empty
    | Branch of Tree * int * Tree
```

with JSON like:

```json
[ 
  null, 
  3, 
  [
    [ null, 5, null ], 
    4, 
    null 
  ]
]
```

We can build a decoder like this:

```fsharp
module Tree = 

    let decode =
        Decode.fix (fun self ->
            Decode.oneOf
                [
                    Decode.unit
                    |> Decode.map (fun () -> Tree.Empty)

                    Decode.tuple3 self Decode.int self
                    |> Decode.map Tree.Branch
                ]
        )
```

Before `Thoth.Json.Core`, this could be achieved with recursive functions, but now, a combinator like this is needed. 