### PR TITLE
feat: add support for `Encode.value` and `Decode.value`

### DIFF
--- a/packages/Thoth.Json.Core/Decode.fs
+++ b/packages/Thoth.Json.Core/Decode.fs
@@ -841,7 +841,75 @@ module Decode =
                     ("", BadPrimitive("null", value)) |> Error
         }
 
-    let value _ v = Ok v
+    type private ValueDecoder() =
+        interface Decoder<Json> with
+            member this.Decode
+                (helpers: IDecoderHelpers<'JsonValue>, value: 'JsonValue)
+                : Result<Json, DecoderError<'JsonValue>>
+                =
+                let decoder = this :> Decoder<_>
+
+                if helpers.isBoolean value then
+                    helpers.asBoolean value |> Json.Boolean |> Ok
+                elif helpers.isNullValue value then
+                    Json.Null |> Ok
+                elif helpers.isString value then
+                    helpers.asString value |> Json.String |> Ok
+                // elif helpers.isIntegralValue value then
+                //     helpers.asInt value |> Json.Number |> Ok
+                elif helpers.isNumber value then
+                    helpers.asString value |> Json.Number |> Ok
+                elif helpers.isArray value then
+                    let tokens = helpers.asArray value
+                    let result = Array.zeroCreate (Array.length tokens)
+
+                    let mutable i = 0
+                    let mutable error: DecoderError<_> option = None
+
+                    while i < tokens.Length && error.IsNone do
+                        let value = tokens.[i]
+
+                        match decoder.Decode(helpers, value) with
+                        | Ok value -> result[i] <- value
+                        | Error er ->
+                            let x = Some(er |> Helpers.prependPath $".[%i{i}]")
+
+                            error <- x
+
+                        i <- i + 1
+
+                    if error.IsNone then
+                        result |> Seq.toList |> Json.Array |> Ok
+                    else
+                        Error error.Value
+                elif helpers.isObject value then
+                    let props = helpers.getProperties value |> Seq.toArray
+                    let result = Array.zeroCreate (Array.length props)
+
+                    let mutable i = 0
+                    let mutable error: DecoderError<_> option = None
+
+                    while i < props.Length && error.IsNone do
+                        let key = props[i]
+                        let value = helpers.getProperty (key, value)
+
+                        match decoder.Decode(helpers, value) with
+                        | Ok value -> result[i] <- key, value
+                        | Error er ->
+                            let x = Some(er |> Helpers.prependPath ("." + key))
+
+                            error <- x
+
+                        i <- i + 1
+
+                    if error.IsNone then
+                        result |> Seq.toList |> Json.Object |> Ok
+                    else
+                        Error error.Value
+                else
+                    Error("", BadPrimitive("any", value))
+
+    let value: Decoder<Json> = ValueDecoder()
 
     let succeed (output: 'a) : Decoder<'a> =
         { new Decoder<'a> with

--- a/packages/Thoth.Json.Core/Decode.fs
+++ b/packages/Thoth.Json.Core/Decode.fs
@@ -855,10 +855,8 @@ module Decode =
                     Json.Null |> Ok
                 elif helpers.isString value then
                     helpers.asString value |> Json.String |> Ok
-                // elif helpers.isIntegralValue value then
-                //     helpers.asInt value |> Json.Number |> Ok
                 elif helpers.isNumber value then
-                    helpers.asString value |> Json.Number |> Ok
+                    helpers.asFloat value |> Json.Number |> Ok
                 elif helpers.isArray value then
                     let tokens = helpers.asArray value
                     let result = Array.zeroCreate (Array.length tokens)

--- a/packages/Thoth.Json.Core/Encode.fs
+++ b/packages/Thoth.Json.Core/Encode.fs
@@ -359,6 +359,17 @@ module Encode =
                     "$case", string "none"
                 ]
 
+    let rec value: Encoder<Json> =
+        fun json ->
+            match json with
+            | Json.Null -> nil
+            | Json.Boolean b -> bool b
+            | Json.String s -> string s
+            | Json.Number f -> float f
+            | Json.Array xs -> list (List.map value xs)
+            | Json.Object kvps ->
+                kvps |> Seq.map (fun (k, v) -> k, value v) |> object
+
     let inline toJsonValue
         (helpers: IEncoderHelpers<'JsonValue>)
         (json: IEncodable)

--- a/packages/Thoth.Json.Core/Types.fs
+++ b/packages/Thoth.Json.Core/Types.fs
@@ -1,7 +1,5 @@
 namespace Thoth.Json.Core
 
-open System.Numerics
-
 type IDecoderHelpers<'JsonValue> =
     abstract isString: 'JsonValue -> bool
     abstract isNumber: 'JsonValue -> bool
@@ -59,12 +57,13 @@ type Decoder<'T> =
 /// A JSON value
 /// </summary>
 /// <remarks>
-/// Numbers are representated as `string` so that the consumer can decide on precision
+/// Although theoretically numbers are arbitrary prevision in JSON,
+/// here they are representated as `float`, which is in line with most implementations.
 /// </remarks>
 [<RequireQualifiedAccess; NoComparison>]
 type Json =
     | String of string
-    | Number of string
+    | Number of float
     | Null
     | Boolean of bool
     | Object of (string * Json) list

--- a/packages/Thoth.Json.Core/Types.fs
+++ b/packages/Thoth.Json.Core/Types.fs
@@ -1,5 +1,7 @@
 namespace Thoth.Json.Core
 
+open System.Numerics
+
 type IDecoderHelpers<'JsonValue> =
     abstract isString: 'JsonValue -> bool
     abstract isNumber: 'JsonValue -> bool
@@ -57,24 +59,16 @@ type Decoder<'T> =
 /// A JSON value
 /// </summary>
 /// <remarks>
-/// Some types don't have a direct representation in this DU,
-/// this to make sure we represent them in the same way between the different
-/// backends.
-///
-/// For example, <c>decimal</c> use <c>string</c> as the underlying type.
+/// Numbers are representated as `string` so that the consumer can decide on precision
 /// </remarks>
 [<RequireQualifiedAccess; NoComparison>]
 type Json =
     | String of string
-    | Char of char
-    | DecimalNumber of float
+    | Number of string
     | Null
     | Boolean of bool
-    | Object of (string * Json) seq
-    | Array of Json[]
-    // Thoth.Json as an abritrary limit to the size of numbers
-    | IntegralNumber of uint32
-    | Unit
+    | Object of (string * Json) list
+    | Array of Json list
 
 type IEncodable =
     abstract member Encode<'JsonValue> :

--- a/tests/Thoth.Json.Tests/Decoders.fs
+++ b/tests/Thoth.Json.Tests/Decoders.fs
@@ -2868,6 +2868,72 @@ Expecting an object with a field named `version` but instead got:
                                 "[ null, 3, [ [ null, 5, null ], 4, null ]]"
 
                         equal expected actual
+
+
+                    testCase "value works for a string"
+                    <| fun _ ->
+                        let expected = Ok(Json.String "abcdef")
+
+                        let actual =
+                            runner.Decode.fromString Decode.value "\"abcdef\""
+
+                        equal expected actual
+
+
+                    testCase "value works for a whole number"
+                    <| fun _ ->
+                        let expected = Ok(Json.Number 12345)
+
+                        let actual =
+                            runner.Decode.fromString Decode.value "12345"
+
+                        equal expected actual
+
+
+                    testCase "value works for null"
+                    <| fun _ ->
+                        let expected = Ok Json.Null
+
+                        let actual =
+                            runner.Decode.fromString Decode.value "null"
+
+                        equal expected actual
+
+
+                    testCase "value works for the kitchen sink"
+                    <| fun _ ->
+                        let expected =
+                            Json.Object
+                                [
+                                    "foo", Json.Boolean true
+                                    "bar",
+                                    Json.Object
+                                        [
+                                            "qux",
+                                            Json.Array
+                                                [
+                                                    Json.Number 1.23
+                                                    Json.String "abc"
+                                                ]
+                                            "baz", Json.Null
+                                        ]
+                                ]
+                            |> Ok
+
+                        let json =
+                            """
+                            {
+                                "foo": true,
+                                "bar": {
+                                  "qux": [ 1.23, "abc" ],
+                                  "baz": null
+                                }
+                            }
+                            """
+
+                        let actual = runner.Decode.fromString Decode.value json
+
+                        equal expected actual
                 ]
 
             testList

--- a/tests/Thoth.Json.Tests/Decoders.fs
+++ b/tests/Thoth.Json.Tests/Decoders.fs
@@ -2868,9 +2868,13 @@ Expecting an object with a field named `version` but instead got:
                                 "[ null, 3, [ [ null, 5, null ], 4, null ]]"
 
                         equal expected actual
+                ]
 
+            testList
+                "value"
+                [
 
-                    testCase "value works for a string"
+                    testCase "works for a string"
                     <| fun _ ->
                         let expected = Ok(Json.String "abcdef")
 
@@ -2879,8 +2883,41 @@ Expecting an object with a field named `version` but instead got:
 
                         equal expected actual
 
+                    testCase "works for a char"
+                    <| fun _ ->
+                        let expected = Ok(Json.String "a")
 
-                    testCase "value works for a whole number"
+                        let actual =
+                            runner.Decode.fromString Decode.value "\"a\""
+
+                        equal expected actual
+
+                    testCase "works for a number"
+                    <| fun _ ->
+                        let expected = Ok(Json.Number 1.23)
+
+                        let actual =
+                            runner.Decode.fromString Decode.value "1.23"
+
+                        equal expected actual
+
+                    testCase "works for zero"
+                    <| fun _ ->
+                        let expected = Ok(Json.Number 0.0)
+
+                        let actual = runner.Decode.fromString Decode.value "0"
+
+                        equal expected actual
+
+                    testCase "works for negative number"
+                    <| fun _ ->
+                        let expected = Ok(Json.Number -1.0)
+
+                        let actual = runner.Decode.fromString Decode.value "-1"
+
+                        equal expected actual
+
+                    testCase "works for a whole number"
                     <| fun _ ->
                         let expected = Ok(Json.Number 12345)
 
@@ -2889,8 +2926,16 @@ Expecting an object with a field named `version` but instead got:
 
                         equal expected actual
 
+                    testCase "works for scientific notation"
+                    <| fun _ ->
+                        let expected = Ok(Json.Number 1.5e10)
 
-                    testCase "value works for null"
+                        let actual =
+                            runner.Decode.fromString Decode.value "1.5e10"
+
+                        equal expected actual
+
+                    testCase "works for null"
                     <| fun _ ->
                         let expected = Ok Json.Null
 
@@ -2899,8 +2944,48 @@ Expecting an object with a field named `version` but instead got:
 
                         equal expected actual
 
+                    testCase "works for boolean"
+                    <| fun _ ->
+                        let expected = Ok(Json.Boolean true)
 
-                    testCase "value works for the kitchen sink"
+                        let actual =
+                            runner.Decode.fromString Decode.value "true"
+
+                        equal expected actual
+
+
+                    testCase "works for null"
+                    <| fun _ ->
+                        let expected = Ok Json.Null
+
+                        let actual =
+                            runner.Decode.fromString Decode.value "null"
+
+                        equal expected actual
+
+                    testCase "works for arrays"
+                    <| fun _ ->
+                        let expected =
+                            Ok(
+                                Json.Array
+                                    [
+                                        Json.Number 1.23
+                                        Json.String "abc"
+                                        Json.Boolean true
+                                        Json.Null
+                                    ]
+                            )
+
+                        let json =
+                            """
+                            [ 1.23, "abc", true, null ]
+                            """
+
+                        let actual = runner.Decode.fromString Decode.value json
+
+                        equal expected actual
+
+                    testCase "works objects"
                     <| fun _ ->
                         let expected =
                             Json.Object

--- a/tests/Thoth.Json.Tests/Encoders.fs
+++ b/tests/Thoth.Json.Tests/Encoders.fs
@@ -1103,4 +1103,42 @@ let tests (runner: TestRunner<_, _>) =
 
                 ]
 
+            testList
+                "Fancy encoding"
+                [
+                    testCase "value works for the kitchen sink"
+                    <| fun _ ->
+                        let expected =
+                            """{
+    "foo": true,
+    "bar": {
+        "qux": [
+            1.23,
+            "abc"
+        ],
+        "baz": null
+    }
+}"""
+
+                        let actual =
+                            Json.Object
+                                [
+                                    "foo", Json.Boolean true
+                                    "bar",
+                                    Json.Object
+                                        [
+                                            "qux",
+                                            Json.Array
+                                                [
+                                                    Json.Number 1.23
+                                                    Json.String "abc"
+                                                ]
+                                            "baz", Json.Null
+                                        ]
+                                ]
+                            |> Encode.value
+                            |> runner.Encode.toString 4
+
+                        equal expected actual
+                ]
         ]


### PR DESCRIPTION
This PR brings back `Decode.value` and `Encode.value`. 

These allow JSON to be transformed in and out of a backend-agnostic JSON representation in `Thoth.Json.Core`. 

With these, the user can say "any valid JSON would go here".

For example:

```fsharp
open Thoth.Json.Core


type Message = 
  {
    Sender : string
    Subject : string
    Metadata : Json
  }


[<RequireQualifiedAccess>]
module Message =

  let decode : Decoder<Message> =
    Decode.object 
      (fun get -> 
        {
          Sender = get.Required.Field "sender" Decode.string
          Subject = get.Required.Field "subject" Decode.string
          Metadata = get.Required.Field "metadata" Decode.value
        })
```

I have marked this as draft because there is a decision to make around integer precision:

 - Technically JSON spec allows arbitrarily large/precise numbers. 
 - Most implementations restrict numbers to be a `float`. 
 - To be fully general, we should represent numbers using something like a `BigDecimal`.
     - However, `BigDecimal`  is not part of the .NET standard libraries.
     - Or perhaps a `string`... but I expect most users would want a number to work with. 
     - Or perhaps we could include our own number representation in the library?
 - The current choice is `float`.
 - `IDecoderHelpers` and `IEncoderHelpers`, as they stand now, do not support arbitrary numbers.