### PR TITLE
fix: error location in `Decode.keyValuePairs`

### DIFF
--- a/packages/Thoth.Json.Core/Decode.fs
+++ b/packages/Thoth.Json.Core/Decode.fs
@@ -799,7 +799,8 @@ module Decode =
                             let fieldValue = helpers.getProperty (prop, value)
 
                             match decoder.Decode(helpers, fieldValue) with
-                            | Error er -> Error er
+                            | Error er ->
+                                Error(Helpers.prependPath ("." + prop) er)
                             | Ok value -> (prop, value) :: acc |> Ok
                     )
                     |> Result.map List.rev

--- a/tests/Thoth.Json.Tests/Decoders.fs
+++ b/tests/Thoth.Json.Tests/Decoders.fs
@@ -1853,6 +1853,21 @@ Expecting an array but instead got: 1
 
                         equal expected actual
 
+                    testCase
+                        "keyValuePairs with an invalid value outputs an error"
+                    <| fun _ ->
+                        let expected =
+                            Error
+                                """Error at: `$.b`
+Expecting a boolean but instead got: 123"""
+
+                        let actual =
+                            runner.Decode.fromString
+                                (Decode.keyValuePairs Decode.bool)
+                                """{ "a": true, "b": 123, "c": false }"""
+
+                        equal actual expected
+
                     testCase "dict works"
                     <| fun _ ->
                         let expected =


### PR DESCRIPTION
Fixes the error location in `Decode.keyValuePairs` and adds a test.

Relates to https://github.com/thoth-org/Thoth.Json.Net/issues/58