### PR TITLE
feat: allow caller to pass STJ options to encode and decode

### DIFF
--- a/packages/Thoth.Json.System.Text.Json/Decode.fs
+++ b/packages/Thoth.Json.System.Text.Json/Decode.fs
@@ -72,11 +72,12 @@ module Decode =
     let fromValue (decoder: Decoder<'T>) =
         Decode.Advanced.fromValue helpers decoder
 
-    let fromString (decoder: Decoder<'T>) =
+    let fromStringWithOptions
+        (options: JsonDocumentOptions)
+        (decoder: Decoder<'T>)
+        =
         fun (value: string) ->
             try
-                let options = JsonDocumentOptions(AllowTrailingCommas = true)
-
                 let jsonDocument = JsonDocument.Parse(value, options)
 
                 match decoder.Decode(helpers, jsonDocument.RootElement) with
@@ -86,6 +87,11 @@ module Decode =
                     Error(Decode.errorToString helpers finalError)
             with :? JsonException as ex ->
                 Error("Given an invalid JSON: " + ex.Message)
+
+    let fromString (decoder: Decoder<'T>) =
+        let options = JsonDocumentOptions(AllowTrailingCommas = true)
+
+        fromStringWithOptions options decoder
 
     let unsafeFromString (decoder: Decoder<'T>) =
         fun value ->

--- a/packages/Thoth.Json.System.Text.Json/Encode.fs
+++ b/packages/Thoth.Json.System.Text.Json/Encode.fs
@@ -36,8 +36,16 @@ module Encode =
                 JsonValue.Create(value)
         }
 
-    let toString (space: int) (value: IEncodable) : string =
+    let toStringWithOptions
+        (options: JsonSerializerOptions)
+        (value: IEncodable)
+        : string
+        =
         let json = Encode.toJsonValue helpers value
+
+        JsonSerializer.Serialize(json, options)
+
+    let toString (space: int) (value: IEncodable) : string =
         let writeIndented = space > 0
 
         let options =
@@ -49,4 +57,4 @@ module Encode =
                     System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
             )
 
-        JsonSerializer.Serialize(json, options)
+        toStringWithOptions options value


### PR DESCRIPTION
 - Adds `Decode.fromStringWithOptions` to `Thoth.Json.System.Text.Json`
 - Adds `Encode.toStringWithOptions` to `Thoth.Json.System.Text.Json`

Closes https://github.com/thoth-org/Thoth.Json/issues/234
Relates to https://github.com/thoth-org/Thoth.Json/issues/194