### PR TITLE
fix: Disallow trailing commas by default

### DIFF
--- a/packages/Thoth.Json.System.Text.Json/Decode.fs
+++ b/packages/Thoth.Json.System.Text.Json/Decode.fs
@@ -89,7 +89,7 @@ module Decode =
                 Error("Given an invalid JSON: " + ex.Message)
 
     let fromString (decoder: Decoder<'T>) =
-        let options = JsonDocumentOptions(AllowTrailingCommas = true)
+        let options = JsonDocumentOptions()
 
         fromStringWithOptions options decoder
 


### PR DESCRIPTION
Disallow trailing commas by default for STJ.

If you want the old behavior, use `Decode.fromStringWithOptions`. 

Closes https://github.com/thoth-org/Thoth.Json/issues/239
Relates to https://github.com/thoth-org/Thoth.Json.Net/issues/52