### PR TITLE
fix: handle int64 and uint64 outside of float precision

### DIFF
--- a/packages/Thoth.Json.Core/Decode.fs
+++ b/packages/Thoth.Json.Core/Decode.fs
@@ -283,7 +283,7 @@ module Decode =
         { new Decoder<'T> with
             member _.Decode(helpers, value) =
                 if helpers.isNumber value then
-                    let rawText = helpers.anyToString value
+                    let rawText = helpers.numberToString value
 
                     match tryParse rawText with
                     | true, x -> Ok x

--- a/packages/Thoth.Json.Core/Decode.fs
+++ b/packages/Thoth.Json.Core/Decode.fs
@@ -275,6 +275,27 @@ module Decode =
                     ("", BadPrimitive(name, value)) |> Error
         }
 
+    let inline private bigIntegral
+        (name: string)
+        (tryParse: string -> bool * 'T)
+        : Decoder<'T>
+        =
+        { new Decoder<'T> with
+            member _.Decode(helpers, value) =
+                if helpers.isNumber value then
+                    let rawText = helpers.anyToString value
+
+                    match tryParse rawText with
+                    | true, x -> Ok x
+                    | _ -> ("", BadPrimitive(name, value)) |> Error
+                elif helpers.isString value then
+                    match tryParse (helpers.asString value) with
+                    | true, x -> Ok x
+                    | _ -> ("", BadPrimitive(name, value)) |> Error
+                else
+                    ("", BadPrimitive(name, value)) |> Error
+        }
+
     let sbyte: Decoder<sbyte> =
         integral
             "a sbyte"
@@ -325,64 +346,32 @@ module Decode =
             uint32
 
     let int64: Decoder<int64> =
-        let name = "an int64"
-
         let tryParse (text: string) =
 #if FABLE_COMPILER_JAVASCRIPT || FABLE_COMPILER_PYTHON
             System.Int64.TryParse(text)
 #else
             System.Int64.TryParse(
                 text,
-                NumberStyles.AllowLeadingSign,
+                NumberStyles.Integer ||| NumberStyles.AllowExponent,
                 CultureInfo.InvariantCulture
             )
 #endif
 
-        { new Decoder<int64> with
-            member _.Decode(helpers, value) =
-                if helpers.isNumber value then
-                    let rawText = helpers.anyToString value
-
-                    match tryParse rawText with
-                    | true, x -> Ok x
-                    | _ -> ("", BadPrimitive(name, value)) |> Error
-                elif helpers.isString value then
-                    match tryParse (helpers.asString value) with
-                    | true, x -> Ok x
-                    | _ -> ("", BadPrimitive(name, value)) |> Error
-                else
-                    ("", BadPrimitive(name, value)) |> Error
-        }
+        bigIntegral "an int64" tryParse
 
     let uint64: Decoder<uint64> =
-        let name = "an uint64"
-
         let tryParse (text: string) =
 #if FABLE_COMPILER_JAVASCRIPT || FABLE_COMPILER_PYTHON
             System.UInt64.TryParse(text)
 #else
             System.UInt64.TryParse(
                 text,
-                NumberStyles.AllowLeadingSign,
+                NumberStyles.Integer ||| NumberStyles.AllowExponent,
                 CultureInfo.InvariantCulture
             )
 #endif
 
-        { new Decoder<uint64> with
-            member _.Decode(helpers, value) =
-                if helpers.isNumber value then
-                    let rawText = helpers.anyToString value
-
-                    match tryParse rawText with
-                    | true, x -> Ok x
-                    | _ -> ("", BadPrimitive(name, value)) |> Error
-                elif helpers.isString value then
-                    match tryParse (helpers.asString value) with
-                    | true, x -> Ok x
-                    | _ -> ("", BadPrimitive(name, value)) |> Error
-                else
-                    ("", BadPrimitive(name, value)) |> Error
-        }
+        bigIntegral "an uint64" tryParse
 
     let bigint: Decoder<bigint> =
         { new Decoder<bigint> with

--- a/packages/Thoth.Json.Core/Decode.fs
+++ b/packages/Thoth.Json.Core/Decode.fs
@@ -325,20 +325,56 @@ module Decode =
             uint32
 
     let int64: Decoder<int64> =
-        integral
-            "an int64"
-            System.Int64.TryParse
-            (fun () -> System.Int64.MinValue)
-            (fun () -> System.Int64.MaxValue)
-            int64
+        let name = "an int64"
+
+        let tryParse text =
+            System.Int64.TryParse(
+                text,
+                NumberStyles.AllowLeadingSign,
+                CultureInfo.InvariantCulture
+            )
+
+        { new Decoder<int64> with
+            member _.Decode(helpers, value) =
+                if helpers.isNumber value then
+                    let rawText = helpers.anyToString value
+
+                    match tryParse rawText with
+                    | true, x -> Ok x
+                    | _ -> ("", BadPrimitive(name, value)) |> Error
+                elif helpers.isString value then
+                    match tryParse (helpers.asString value) with
+                    | true, x -> Ok x
+                    | _ -> ("", BadPrimitive(name, value)) |> Error
+                else
+                    ("", BadPrimitive(name, value)) |> Error
+        }
 
     let uint64: Decoder<uint64> =
-        integral
-            "an uint64"
-            System.UInt64.TryParse
-            (fun () -> System.UInt64.MinValue)
-            (fun () -> System.UInt64.MaxValue)
-            uint64
+        let name = "an uint64"
+
+        let tryParse text =
+            System.UInt64.TryParse(
+                text,
+                NumberStyles.AllowLeadingSign,
+                CultureInfo.InvariantCulture
+            )
+
+        { new Decoder<uint64> with
+            member _.Decode(helpers, value) =
+                if helpers.isNumber value then
+                    let rawText = helpers.anyToString value
+
+                    match tryParse rawText with
+                    | true, x -> Ok x
+                    | _ -> ("", BadPrimitive(name, value)) |> Error
+                elif helpers.isString value then
+                    match tryParse (helpers.asString value) with
+                    | true, x -> Ok x
+                    | _ -> ("", BadPrimitive(name, value)) |> Error
+                else
+                    ("", BadPrimitive(name, value)) |> Error
+        }
 
     let bigint: Decoder<bigint> =
         { new Decoder<bigint> with

--- a/packages/Thoth.Json.Core/Decode.fs
+++ b/packages/Thoth.Json.Core/Decode.fs
@@ -327,12 +327,16 @@ module Decode =
     let int64: Decoder<int64> =
         let name = "an int64"
 
-        let tryParse text =
+        let tryParse (text: string) =
+#if FABLE_COMPILER_JAVASCRIPT || FABLE_COMPILER_PYTHON
+            System.Int64.TryParse(text)
+#else
             System.Int64.TryParse(
                 text,
                 NumberStyles.AllowLeadingSign,
                 CultureInfo.InvariantCulture
             )
+#endif
 
         { new Decoder<int64> with
             member _.Decode(helpers, value) =
@@ -353,12 +357,16 @@ module Decode =
     let uint64: Decoder<uint64> =
         let name = "an uint64"
 
-        let tryParse text =
+        let tryParse (text: string) =
+#if FABLE_COMPILER_JAVASCRIPT || FABLE_COMPILER_PYTHON
+            System.UInt64.TryParse(text)
+#else
             System.UInt64.TryParse(
                 text,
                 NumberStyles.AllowLeadingSign,
                 CultureInfo.InvariantCulture
             )
+#endif
 
         { new Decoder<uint64> with
             member _.Decode(helpers, value) =

--- a/packages/Thoth.Json.Core/Types.fs
+++ b/packages/Thoth.Json.Core/Types.fs
@@ -18,6 +18,7 @@ type IDecoderHelpers<'JsonValue> =
     abstract getProperty: string * 'JsonValue -> 'JsonValue
     abstract getProperties: 'JsonValue -> string seq
     abstract anyToString: 'JsonValue -> string
+    abstract numberToString: 'JsonValue -> string
 
 type IEncoderHelpers<'JsonValue> =
     abstract encodeString: string -> 'JsonValue

--- a/packages/Thoth.Json.JavaScript/Decode.fs
+++ b/packages/Thoth.Json.JavaScript/Decode.fs
@@ -57,6 +57,13 @@ return isFinite($0) && Math.floor($0) === $0
                     """
 return JSON.stringify($0, null, 4) + ''
                     """
+
+            member _.numberToString jsonValue =
+                emitJsStatement
+                    jsonValue
+                    """
+return String($0)
+                    """
         }
 
     module Interop =

--- a/packages/Thoth.Json.Newtonsoft/Decode.fs
+++ b/packages/Thoth.Json.Newtonsoft/Decode.fs
@@ -3,6 +3,7 @@ namespace Thoth.Json.Newtonsoft
 open Thoth.Json.Core
 open Newtonsoft.Json
 open Newtonsoft.Json.Linq
+open System.Globalization
 open System.IO
 
 [<RequireQualifiedAccess>]
@@ -71,6 +72,16 @@ module Decode =
 
                     jsonValue.WriteTo(jsonWriter)
                     stream.ToString()
+
+            member _.numberToString jsonValue =
+                if isNull jsonValue then
+                    "null"
+                elif jsonValue.Type = JTokenType.Float then
+                    jsonValue
+                        .Value<float>()
+                        .ToString("R", CultureInfo.InvariantCulture)
+                else
+                    jsonValue.ToString()
         }
 
 type Decode =

--- a/packages/Thoth.Json.Python/Decode.fs
+++ b/packages/Thoth.Json.Python/Decode.fs
@@ -70,6 +70,12 @@ module Decode =
 
             member _.anyToString jsonValue =
                 Fable.Python.Json.Json.dumps (jsonValue, indent = 4)
+
+            member _.numberToString jsonValue =
+                if pyInstanceof jsonValue pyInt || isIntegralType jsonValue then
+                    emitPyStatement jsonValue "return str(int($0))"
+                else
+                    string (unbox<float> jsonValue)
         }
 
 type Decode =

--- a/packages/Thoth.Json.System.Text.Json/Decode.fs
+++ b/packages/Thoth.Json.System.Text.Json/Decode.fs
@@ -67,6 +67,22 @@ module Decode =
                     )
 
                 JsonSerializer.Serialize(jsonValue, options)
+
+            member _.numberToString jsonValue =
+                let mutable int64Value = 0L
+
+                if jsonValue.TryGetInt64(&int64Value) then
+                    string int64Value
+                else
+                    let d = jsonValue.GetDouble()
+
+                    if System.Math.Floor(d) = d then
+                        string (int64 d)
+                    else
+                        d.ToString(
+                            "R",
+                            System.Globalization.CultureInfo.InvariantCulture
+                        )
         }
 
 type Decode =

--- a/tests/Thoth.Json.Tests/BackAndForth.fs
+++ b/tests/Thoth.Json.Tests/BackAndForth.fs
@@ -86,4 +86,41 @@ let tests (runner: TestRunner<_, _>) =
 
                 equal (Ok expected) decoded
 
+            testCase "int64 is symmetric"
+            <| fun _ ->
+                let cases =
+                    [
+                        0L
+                        1L
+                        2L
+                        System.Int64.MaxValue
+                        System.Int64.MinValue
+                    ]
+
+                for expected in cases do
+                    let json =
+                        expected |> Encode.int64 |> runner.Encode.toString 0
+
+                    let decoded = runner.Decode.fromString Decode.int64 json
+
+                    equal (Ok expected) decoded
+
+            testCase "uint64 is symmetric"
+            <| fun _ ->
+                let cases =
+                    [
+                        0UL
+                        1UL
+                        2UL
+                        System.UInt64.MaxValue
+                        System.UInt64.MinValue
+                    ]
+
+                for expected in cases do
+                    let json =
+                        expected |> Encode.uint64 |> runner.Encode.toString 0
+
+                    let decoded = runner.Decode.fromString Decode.uint64 json
+
+                    equal (Ok expected) decoded
         ]

--- a/tests/Thoth.Json.Tests/BackAndForth.fs
+++ b/tests/Thoth.Json.Tests/BackAndForth.fs
@@ -93,6 +93,12 @@ let tests (runner: TestRunner<_, _>) =
                         0L
                         1L
                         2L
+                        -1L
+                        -2L
+                        9007199254740993L
+                        -9007199254740993L
+                        123456789012345L
+                        -123456789012345L
                         System.Int64.MaxValue
                         System.Int64.MinValue
                     ]
@@ -113,6 +119,10 @@ let tests (runner: TestRunner<_, _>) =
                         0UL
                         1UL
                         2UL
+                        9007199254740993UL
+                        9223372036854775808UL
+                        123456789012345UL
+                        999999999999UL
                         System.UInt64.MaxValue
                         System.UInt64.MinValue
                     ]

--- a/tests/Thoth.Json.Tests/BackAndForth.fs
+++ b/tests/Thoth.Json.Tests/BackAndForth.fs
@@ -105,6 +105,7 @@ let tests (runner: TestRunner<_, _>) =
 
                     equal (Ok expected) decoded
 
+#if !FABLE_COMPILER_PYTHON
             testCase "uint64 is symmetric"
             <| fun _ ->
                 let cases =
@@ -123,4 +124,5 @@ let tests (runner: TestRunner<_, _>) =
                     let decoded = runner.Decode.fromString Decode.uint64 json
 
                     equal (Ok expected) decoded
+#endif
         ]

--- a/tests/Thoth.Json.Tests/Decoders.fs
+++ b/tests/Thoth.Json.Tests/Decoders.fs
@@ -600,6 +600,28 @@ Expecting an uint16 but instead got: "maxime"
 
                         equal expected actual
 
+                    testCase "an int64 works from large number"
+                    <| fun _ ->
+                        let expected = Ok 9223372036854775806L
+
+                        let actual =
+                            runner.Decode.fromString
+                                Decode.int64
+                                "9223372036854775806"
+
+                        equal expected actual
+
+                    testCase "an int64 works from large string"
+                    <| fun _ ->
+                        let expected = Ok 9223372036854775806L
+
+                        let actual =
+                            runner.Decode.fromString
+                                Decode.int64
+                                "\"9223372036854775806\""
+
+                        equal expected actual
+
                     testCase
                         "an int64 works output an error if incorrect string"
                     <| fun _ ->
@@ -666,6 +688,28 @@ Expecting an uint32 but instead got: "maxime"
 
                         let actual =
                             runner.Decode.fromString Decode.uint64 "\"1000\""
+
+                        equal expected actual
+
+                    testCase "an uint64 works from large number"
+                    <| fun _ ->
+                        let expected = Ok 9223372036854775806UL
+
+                        let actual =
+                            runner.Decode.fromString
+                                Decode.uint64
+                                "9223372036854775806"
+
+                        equal expected actual
+
+                    testCase "an uint64 works from large string"
+                    <| fun _ ->
+                        let expected = Ok 9223372036854775806UL
+
+                        let actual =
+                            runner.Decode.fromString
+                                Decode.uint64
+                                "\"9223372036854775806\""
 
                         equal expected actual
 

--- a/tests/Thoth.Json.Tests/Decoders.fs
+++ b/tests/Thoth.Json.Tests/Decoders.fs
@@ -600,6 +600,24 @@ Expecting an uint16 but instead got: "maxime"
 
                         equal expected actual
 
+                    testCase "an int64 works from negative string"
+                    <| fun _ ->
+                        let expected = Ok -99L
+
+                        let actual =
+                            runner.Decode.fromString Decode.int64 "\"-99\""
+
+                        equal expected actual
+
+                    testCase "an int64 works from string with leading plus"
+                    <| fun _ ->
+                        let expected = Ok 99L
+
+                        let actual =
+                            runner.Decode.fromString Decode.int64 "\"+99\""
+
+                        equal expected actual
+
                     // This is beyond the range of `JSON.parse`
 #if !FABLE_COMPILER_JAVASCRIPT
                     testCase "an int64 works from large number"
@@ -691,6 +709,15 @@ Expecting an uint32 but instead got: "maxime"
 
                         let actual =
                             runner.Decode.fromString Decode.uint64 "\"1000\""
+
+                        equal expected actual
+
+                    testCase "an uint64 works from string with leading plus"
+                    <| fun _ ->
+                        let expected = Ok 99UL
+
+                        let actual =
+                            runner.Decode.fromString Decode.uint64 "\"+99\""
 
                         equal expected actual
 

--- a/tests/Thoth.Json.Tests/Decoders.fs
+++ b/tests/Thoth.Json.Tests/Decoders.fs
@@ -643,6 +643,28 @@ Expecting an uint16 but instead got: "maxime"
 
                         equal expected actual
 
+                    testCase "an int64 works from scientific notation"
+                    <| fun _ ->
+                        let expected = Ok 1000L
+
+                        let actual = runner.Decode.fromString Decode.int64 "1e3"
+
+                        equal expected actual
+
+                    testCase "the backend numberToString of 1e3"
+                    <| fun _ ->
+                        let reprDecoder =
+                            { new Decoder<string> with
+                                member _.Decode(helpers, value) =
+                                    Ok(helpers.numberToString value)
+                            }
+
+                        let expected = Ok "1000"
+
+                        let actual = runner.Decode.fromString reprDecoder "1e3"
+
+                        equal expected actual
+
                     testCase
                         "an int64 works output an error if incorrect string"
                     <| fun _ ->
@@ -743,6 +765,15 @@ Expecting an uint32 but instead got: "maxime"
                             runner.Decode.fromString
                                 Decode.uint64
                                 "\"9223372036854775806\""
+
+                        equal expected actual
+
+                    testCase "an uint64 works from scientific notation"
+                    <| fun _ ->
+                        let expected = Ok 1000UL
+
+                        let actual =
+                            runner.Decode.fromString Decode.uint64 "1e3"
 
                         equal expected actual
 

--- a/tests/Thoth.Json.Tests/Decoders.fs
+++ b/tests/Thoth.Json.Tests/Decoders.fs
@@ -600,6 +600,8 @@ Expecting an uint16 but instead got: "maxime"
 
                         equal expected actual
 
+                    // This is beyond the range of `JSON.parse`
+#if !FABLE_COMPILER_JAVASCRIPT
                     testCase "an int64 works from large number"
                     <| fun _ ->
                         let expected = Ok 9223372036854775806L
@@ -610,6 +612,7 @@ Expecting an uint16 but instead got: "maxime"
                                 "9223372036854775806"
 
                         equal expected actual
+#endif
 
                     testCase "an int64 works from large string"
                     <| fun _ ->
@@ -691,6 +694,8 @@ Expecting an uint32 but instead got: "maxime"
 
                         equal expected actual
 
+                    // This is beyond the range of `JSON.parse`
+#if !FABLE_COMPILER_JAVASCRIPT
                     testCase "an uint64 works from large number"
                     <| fun _ ->
                         let expected = Ok 9223372036854775806UL
@@ -701,6 +706,7 @@ Expecting an uint32 but instead got: "maxime"
                                 "9223372036854775806"
 
                         equal expected actual
+#endif
 
                     testCase "an uint64 works from large string"
                     <| fun _ ->


### PR DESCRIPTION
 * Changes `Decode.int64` and `Decode.uint64` to work via strings. This better leverages the .NET standard library to ensure portability. 
 * Adds better test coverage for `int64` and `unit64`

Closes https://github.com/thoth-org/Thoth.Json.Net/issues/60
Closes https://github.com/thoth-org/Thoth.Json/issues/220