### PR TITLE
fix(decode): use invariant culture for decimal strings

### DIFF
--- a/packages/Thoth.Json.Core/Decode.fs
+++ b/packages/Thoth.Json.Core/Decode.fs
@@ -367,7 +367,13 @@ module Decode =
                 if helpers.isNumber value then
                     helpers.asFloat value |> decimal |> Ok
                 elif helpers.isString value then
-                    match System.Decimal.TryParse(helpers.asString value) with
+                    match
+                        System.Decimal.TryParse(
+                            helpers.asString value,
+                            NumberStyles.Number,
+                            CultureInfo.InvariantCulture
+                        )
+                    with
                     | true, x -> Ok x
                     | _ -> ("", BadPrimitive("a decimal", value)) |> Error
                 else

--- a/packages/Thoth.Json/Decode.fs
+++ b/packages/Thoth.Json/Decode.fs
@@ -358,7 +358,13 @@ module Decode =
             if Helpers.isNumber value then
                 Helpers.asFloat value |> decimal |> Ok
             elif Helpers.isString value then
-                match System.Decimal.TryParse(Helpers.asString value) with
+                match
+                    System.Decimal.TryParse(
+                        Helpers.asString value,
+                        NumberStyles.Number,
+                        CultureInfo.InvariantCulture
+                    )
+                with
                 | true, x -> Ok x
                 | _ -> (path, BadPrimitive("a decimal", value)) |> Error
             else

--- a/tests/Thoth.Json.Tests/Decoders.fs
+++ b/tests/Thoth.Json.Tests/Decoders.fs
@@ -848,36 +848,52 @@ Expecting a bigint but instead got: "maxime"
                         equal expected actual
 
 #if !FABLE_COMPILER_JAVASCRIPT && !FABLE_COMPILER_PYTHON
-                    testCase "a decimal string uses invariant culture"
-                    <| fun _ ->
-                        let previousCulture =
-                            Globalization.CultureInfo.CurrentCulture
+                    testList
+                        "a decimal string uses invariant culture"
+                        ([
+                            "de-DE" // Decimal separator is comma in this culture.
+                            "fi-FI" // Uses U+2212 as negative sign in NumberFormat.
+                            "sv-SE" // Also uses U+2212 as negative sign.
+                            "fa-IR" // Uses right-to-left direction marks with negative sign.
+                            "fr-FR" // Uses non-breaking space as group separator and comma decimal separator.
+                            "ru-RU" // Uses comma decimal separator and non-dot parsing conventions.
+                         ]
+                         |> List.map (fun culture ->
+                             testCase (
+                                 sprintf
+                                     "a decimal string works in %s culture"
+                                     culture
+                             )
+                             <| fun _ ->
+                                 let previousCulture =
+                                     Globalization.CultureInfo.CurrentCulture
 
-                        let previousUiCulture =
-                            Globalization.CultureInfo.CurrentUICulture
+                                 let previousUiCulture =
+                                     Globalization.CultureInfo.CurrentUICulture
 
-                        try
-                            let germanCulture =
-                                Globalization.CultureInfo("de-DE")
+                                 try
+                                     let germanCulture =
+                                         Globalization.CultureInfo(culture)
 
-                            Globalization.CultureInfo.CurrentCulture <-
-                                germanCulture
+                                     Globalization.CultureInfo.CurrentCulture <-
+                                         germanCulture
 
-                            Globalization.CultureInfo.CurrentUICulture <-
-                                germanCulture
+                                     Globalization.CultureInfo.CurrentUICulture <-
+                                         germanCulture
 
-                            let actual =
-                                runner.Decode.fromString
-                                    Decode.decimal
-                                    "\"0.7833\""
+                                     let actual =
+                                         runner.Decode.fromString
+                                             Decode.decimal
+                                             $"\"-1234.75\""
 
-                            equal (Ok 0.7833M) actual
-                        finally
-                            Globalization.CultureInfo.CurrentCulture <-
-                                previousCulture
+                                     equal (Ok -1234.75M) actual
+                                 finally
+                                     Globalization.CultureInfo.CurrentCulture <-
+                                         previousCulture
 
-                            Globalization.CultureInfo.CurrentUICulture <-
-                                previousUiCulture
+                                     Globalization.CultureInfo.CurrentUICulture <-
+                                         previousUiCulture
+                         ))
 #endif
 
                     testCase

--- a/tests/Thoth.Json.Tests/Decoders.fs
+++ b/tests/Thoth.Json.Tests/Decoders.fs
@@ -847,6 +847,39 @@ Expecting a bigint but instead got: "maxime"
 
                         equal expected actual
 
+#if !FABLE_COMPILER_JAVASCRIPT && !FABLE_COMPILER_PYTHON
+                    testCase "a decimal string uses invariant culture"
+                    <| fun _ ->
+                        let previousCulture =
+                            Globalization.CultureInfo.CurrentCulture
+
+                        let previousUiCulture =
+                            Globalization.CultureInfo.CurrentUICulture
+
+                        try
+                            let germanCulture =
+                                Globalization.CultureInfo("de-DE")
+
+                            Globalization.CultureInfo.CurrentCulture <-
+                                germanCulture
+
+                            Globalization.CultureInfo.CurrentUICulture <-
+                                germanCulture
+
+                            let actual =
+                                runner.Decode.fromString
+                                    Decode.decimal
+                                    "\"0.7833\""
+
+                            equal (Ok 0.7833M) actual
+                        finally
+                            Globalization.CultureInfo.CurrentCulture <-
+                                previousCulture
+
+                            Globalization.CultureInfo.CurrentUICulture <-
+                                previousUiCulture
+#endif
+
                     testCase
                         "a string representing a DateTime should be accepted as a string"
                     <| fun _ ->


### PR DESCRIPTION
## Summary
This fixes decimal decoding from JSON strings when the current process culture uses a comma decimal separator.

`Decode.decimal` was using the current culture for string parsing, which meant values like `"0.7833"` could fail under cultures such as `de-DE` even though JSON numbers use `.` as the decimal separator.

## Changes
- parse decimal strings with `CultureInfo.InvariantCulture`
- apply the fix in both `Thoth.Json` and `Thoth.Json.Core`
- add a regression test that switches the current culture to `de-DE` and verifies `"0.7833"` still decodes successfully

## Validation
- `.\\build.bat test newtonsoft`
- `.\\build.bat test system-text-json`