### PR TITLE
perf: Dispose the `JsonDocument` created in `Decode.fromStringWithOptions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Intel Core i9-14900K 0.80GHz, 1 CPU, 32 logical and 24 physical cores
 
 | Method                      | Mean       | Error    | StdDev   | Ratio | RatioSD |
 |---------------------------- |-----------:|---------:|---------:|------:|--------:|
-| System.Text.Json            |   423.4 ns |  1.68 ns |  1.57 ns |  1.00 |    0.01 |
-| Newtonsoft                  |   790.8 ns |  4.27 ns |  4.00 ns |  1.87 |    0.01 |
-| Thoth.Json.System.Text.Json | 1,524.5 ns | 12.77 ns | 11.95 ns |  3.60 |    0.03 |
-| Thoth.Json.Newtonsoft       | 2,059.9 ns |  8.62 ns |  7.64 ns |  4.87 |    0.02 |
+| System.Text.Json            |   434.9 ns |  1.60 ns |  1.49 ns |  1.00 |    0.00 |
+| Newtonsoft                  |   806.6 ns |  1.96 ns |  1.53 ns |  1.85 |    0.01 |
+| Thoth.Json.System.Text.Json | 1,183.1 ns |  3.36 ns |  3.14 ns |  2.72 |    0.01 |
+| Thoth.Json.Newtonsoft       | 2,072.9 ns | 13.54 ns | 12.66 ns |  4.77 |    0.03 |
 ```
 
 ## Blogs post

--- a/packages/Thoth.Json.System.Text.Json/Decode.fs
+++ b/packages/Thoth.Json.System.Text.Json/Decode.fs
@@ -122,7 +122,7 @@ type Decode =
         =
         fun (value: string) ->
             try
-                let jsonDocument = JsonDocument.Parse(value, options)
+                use jsonDocument = JsonDocument.Parse(value, options)
 
                 match
                     decoder.Decode(Decode.helpers, jsonDocument.RootElement)


### PR DESCRIPTION
JsonDocument is a a disposable type.
The documentation at https://learn.microsoft.com/en-us/dotnet/api/system.text.json.jsondocument?view=net-10.0 says that not disposing instances will result in issues with reusing pooled memory.

If I run the benchmarks on the current code, I get this
```
BenchmarkDotNet v0.15.8, Windows 10 (10.0.19045.6466/22H2/2022Update)
AMD Ryzen 9 5950X 3.40GHz, 1 CPU, 32 logical and 16 physical cores
.NET SDK 10.0.109
  [Host]     : .NET 10.0.9 (10.0.9, 10.0.926.27113), X64 RyuJIT x86-64-v3 DEBUG
  DefaultJob : .NET 10.0.9 (10.0.9, 10.0.926.27113), X64 RyuJIT x86-64-v3


| Method                      | Mean       | Error    | StdDev   | Ratio | RatioSD | Gen0   | Gen1   | Allocated | Alloc Ratio |
|---------------------------- |-----------:|---------:|---------:|------:|--------:|-------:|-------:|----------:|------------:|
| System.Text.Json            |   642.7 ns |  1.27 ns |  1.12 ns |  1.00 |    0.00 | 0.0353 |      - |     592 B |        1.00 |
| Newtonsoft                  | 1,049.3 ns |  4.32 ns |  3.61 ns |  1.63 |    0.01 | 0.2327 | 0.0019 |    3920 B |        6.62 |
| Thoth.Json.System.Text.Json | 1,854.6 ns |  7.07 ns |  6.26 ns |  2.89 |    0.01 | 0.1507 |      - |    2544 B |        4.30 |
| Thoth.Json.Newtonsoft       | 2,702.4 ns | 12.07 ns | 11.29 ns |  4.20 |    0.02 | 0.5035 | 0.0076 |    8464 B |       14.30 |
```

And if I dispose the JsonDcocument, I get
```
| Method                      | Mean       | Error    | StdDev   | Ratio | RatioSD | Gen0   | Gen1   | Allocated | Alloc Ratio |
|---------------------------- |-----------:|---------:|---------:|------:|--------:|-------:|-------:|----------:|------------:|
| System.Text.Json            |   644.3 ns |  1.09 ns |  1.02 ns |  1.00 |    0.00 | 0.0353 |      - |     592 B |        1.00 |
| Newtonsoft                  | 1,044.2 ns |  5.60 ns |  5.24 ns |  1.62 |    0.01 | 0.2327 | 0.0019 |    3920 B |        6.62 |
| Thoth.Json.System.Text.Json | 1,645.5 ns |  3.04 ns |  2.85 ns |  2.55 |    0.01 | 0.1030 |      - |    1728 B |        2.92 |
| Thoth.Json.Newtonsoft       | 2,714.7 ns | 15.57 ns | 14.56 ns |  4.21 |    0.02 | 0.5035 | 0.0076 |    8464 B |       14.30 |
```

I have a test case at work with a ~12KB json document, where this changes dropes the reported allocations from ~100KB to ~55KB.

I'm assuming that there is nothing else about that depends on this not being disposed.