### PR TITLE
perf: Tweak System.Text.Json hasProperty helper

### DIFF
--- a/packages/Thoth.Json.System.Text.Json/Decode.fs
+++ b/packages/Thoth.Json.System.Text.Json/Decode.fs
@@ -35,10 +35,10 @@ module Decode =
                 // Result of a benchmark:
                 // Iteration: 5,661.0 ns
                 // TryGetProperty: 4,734.3 ns
-                let d = ref (JsonElement())
-
-                jsonValue.ValueKind = JsonValueKind.Object
-                && jsonValue.TryGetProperty(fieldName, d)
+                match jsonValue.ValueKind with
+                | JsonValueKind.Object ->
+                    jsonValue.TryGetProperty fieldName |> fst
+                | _ -> false
 
             member _.isIntegralValue jsonValue =
                 jsonValue.ValueKind = JsonValueKind.Number


### PR DESCRIPTION
The existing version appears to be allocating a lot of 'FSharpRef' instances (one per read Json property), and I wonder if that needs to be the case?

---

Just a thought I had after running a parser for something I'm working on at work through the Visual Studio memory allocation profiler and getting this:

<img width="1498" height="230" alt="image" src="https://github.com/user-attachments/assets/1bd9b284-855c-4440-af8a-b604d10d6ccc" />

Running the benchmark project from here I barely get any difference (there is a tiny reduction in memory, but perf numbers seem basically the same, though I get quite a bit of variation between runs and the runtime is only a couple of microseconds anyway.

Before (with allocation reporting enabled)
```
| Method                      | Mean     | Error     | StdDev    | Gen0   | Allocated |
|---------------------------- |---------:|----------:|----------:|-------:|----------:|
| Thoth.Json.System.Text.Json | 1.668 us | 0.0023 us | 0.0022 us | 0.1030 |   1.69 KB |
```

After (256 bytes less)
```
| Method                      | Mean     | Error     | StdDev    | Gen0   | Allocated |
|---------------------------- |---------:|----------:|----------:|-------:|----------:|
| Thoth.Json.System.Text.Json | 1.680 us | 0.0050 us | 0.0044 us | 0.0877 |   1.44 KB |
```

However, on the work project I get
Before
```
| Method               | Mean     | Error    | StdDev   | Gen0   | Gen1   | Allocated |
|--------------------- |---------:|---------:|---------:|-------:|-------:|----------:|
| ParseJsonSchema      | 54.31 us | 0.805 us | 0.673 us | 4.4556 | 0.1221 |   56008 B |
```

After (7840 bytes less)
```
| Method               | Mean     | Error    | StdDev   | Gen0   | Gen1   | Allocated |
|--------------------- |---------:|---------:|---------:|-------:|-------:|----------:|
| ParseJsonSchema      | 54.18 us | 1.047 us | 1.164 us | 3.7842 | 0.1221 |   48168 B |
```

I don't know any history here of why it's manually using ```ref``` though, or if something has changed in newer .NET versions, but on .NET 10 at least it doesn't seem to be the most memory efficient way to handle it.