### PR TITLE
feat: tuple union case encoding

### DIFF
--- a/docs/content/documentation/codec/unions.md
+++ b/docs/content/documentation/codec/unions.md
@@ -61,7 +61,7 @@ declared.
 
 Decoding fails unless the object carries exactly one recognised tag.
 
-This is sometimes called "Adjacent tag" encoding.
+This is sometimes called "External tag" encoding.
 
 ### A tag and a value property
 
@@ -101,7 +101,7 @@ printfn "%s" json
 Decode.fromString Shape.codec json |> Docs.print
 ```
 
-This is sometimes called "External tag" encoding.
+This is sometimes called "Adjacent tag" encoding.
 
 ### A tuple of tag and data
 
@@ -113,19 +113,21 @@ This is sometimes called "External tag" encoding.
 [ "rectangle", [ 7, 2 ] ]
 ```
 
-This encoding was used in earlier versions of Thoth.
+This is sometimes called "Internal tag" encoding. It is what earlier versions of Thoth wrote.
 
 ### Intentionally omitted
 
-The "Internally tagged" encoding places payload data into the same object as the type data.
+Two shapes are left out.
+
+The first puts the case fields beside the tag in one object:
 
 ```json
-{ "type": "rectangle", "width": 7, "length": 2 }
+{ "type": "rectangle", "width": 7, "height": 2 }
 ```
 
-This encoding risk mixing union case data with type information.
+A field of the case can then collide with the tag.
 
-The "Untagged" encoding has no type data at all:
+The second carries no tag at all:
 
 ```json
 4
@@ -133,9 +135,7 @@ The "Untagged" encoding has no type data at all:
 [ 7, 2 ]
 ```
 
-*(The prior square and rectangle examples)*
-
-This encoding risks producing JSON that is ambiguous between cases.
+Nothing says which case the value belongs to, so two cases of the same shape cannot be told apart.
 
 ## Cases without fields
 

--- a/docs/content/documentation/codec/unions.md
+++ b/docs/content/documentation/codec/unions.md
@@ -123,6 +123,8 @@ The "Internally tagged" encoding places payload data into the same object as the
 { "type": "rectangle", "width": 7, "length": 2 }
 ```
 
+This encoding risk mixing union case data with type information.
+
 The "Untagged" encoding has no type data at all:
 
 ```json
@@ -133,7 +135,7 @@ The "Untagged" encoding has no type data at all:
 
 *(The prior square and rectangle examples)*
 
-Both of these encodings risk mixing union case data with type information so are intentionally omitted.
+This encoding risks producing JSON that is ambiguous between cases.
 
 ## Cases without fields
 

--- a/docs/content/documentation/codec/unions.md
+++ b/docs/content/documentation/codec/unions.md
@@ -47,7 +47,7 @@ Decode.fromString Shape.codec json |> Docs.print
 A case with several fields takes a `Codec.tuple2` to `Codec.tuple8`, in the order the fields are
 declared.
 
-## The two representations
+## The representations
 
 ### One property per case
 
@@ -60,6 +60,8 @@ declared.
 ```
 
 Decoding fails unless the object carries exactly one recognised tag.
+
+This is sometimes called "Adjacent tag" encoding.
 
 ### A tag and a value property
 
@@ -98,6 +100,40 @@ printfn "%s" json
 
 Decode.fromString Shape.codec json |> Docs.print
 ```
+
+This is sometimes called "External tag" encoding.
+
+### A tuple of tag and data
+
+`variantCodecTuple` writes a two element array where the first element is the union case tag and the second is the case data.
+
+```json
+[ "square", 4 ]
+
+[ "rectangle", [ 7, 2 ] ]
+```
+
+This encoding was used in earlier versions of Thoth.
+
+### Intentionally omitted
+
+The "Internally tagged" encoding places payload data into the same object as the type data.
+
+```json
+{ "type": "rectangle", "width": 7, "length": 2 }
+```
+
+The "Untagged" encoding has no type data at all:
+
+```json
+4
+
+[ 7, 2 ]
+```
+
+*(The prior square and rectangle examples)*
+
+Both of these encodings risk mixing union case data with type information so are intentionally omitted.
 
 ## Cases without fields
 

--- a/packages/Thoth.Json.Core/Variant.fs
+++ b/packages/Thoth.Json.Core/Variant.fs
@@ -47,10 +47,17 @@ module VariantCodecBuilder =
             (x: VariantCase<'t, 'v>)
             : Codec<'v>
             =
-            let decodeForTag tag : Decoder<_> =
+            // The value is read through `descend`, which differs per encoding. The tag is
+            // checked first so an unrecognised one is reported as such rather than as a
+            // missing field.
+            let decodeForTag
+                tag
+                (descend: Decoder<'v> -> Decoder<'v>)
+                : Decoder<_>
+                =
                 match Map.tryFind tag x.Decoders with
-                | Some decoder -> decoder
-                | None -> Decode.fail $"The tag \"{tag}\" was not recognized"
+                | Some decoder -> descend decoder
+                | None -> Decode.fail $"The tag \"%s{tag}\" was not recognized"
 
             Codec.create
                 (fun (v: 'v) -> f x.Value v variantEncoding)
@@ -58,7 +65,7 @@ module VariantCodecBuilder =
                  | TagAndValue(tagName, valueName) ->
                      Decode.field tagName Decode.string
                      |> Decode.andThen (fun tag ->
-                         Decode.field valueName (decodeForTag tag)
+                         decodeForTag tag (Decode.field valueName)
                      )
                  | OnTag ->
                      Decode.keys
@@ -70,7 +77,7 @@ module VariantCodecBuilder =
                              )
 
                          match Seq.tryExactlyOne recognizedKeys with
-                         | Some tag -> Decode.field tag (decodeForTag tag)
+                         | Some tag -> decodeForTag tag (Decode.field tag)
                          | None ->
                              let found =
                                  recognizedKeys
@@ -83,7 +90,7 @@ module VariantCodecBuilder =
                  | Tuple ->
                      Decode.index 0 Decode.string
                      |> Decode.andThen (fun tag ->
-                         Decode.index 1 (decodeForTag tag)
+                         decodeForTag tag (Decode.index 1)
                      ))
 
     /// <summary>

--- a/packages/Thoth.Json.Core/Variant.fs
+++ b/packages/Thoth.Json.Core/Variant.fs
@@ -135,7 +135,7 @@ module VariantCodecBuilder =
     /// <code lang="fsharp">
     /// // [ "square", 4 ]
     /// let codec : Codec&lt;Shape&gt; =
-    ///     variantCodecTuple "type" "value" {
+    ///     variantCodecTuple {
     ///         let! square = Codec.case "square" Square Codec.int
     ///         and! circle = Codec.case "circle" Circle Codec.int
     ///

--- a/packages/Thoth.Json.Core/Variant.fs
+++ b/packages/Thoth.Json.Core/Variant.fs
@@ -10,6 +10,7 @@ module VariantCodecBuilder =
         internal
         | TagAndValue of tagName: string * valueName: string
         | OnTag
+        | Tuple
 
     /// <summary>
     /// The cases declared so far by a <c>variantCodec</c> block.
@@ -46,9 +47,9 @@ module VariantCodecBuilder =
             (x: VariantCase<'t, 'v>)
             : Codec<'v>
             =
-            let decodeForTag tag fieldName : Decoder<_> =
+            let decodeForTag tag : Decoder<_> =
                 match Map.tryFind tag x.Decoders with
-                | Some decoder -> Decode.field fieldName decoder
+                | Some decoder -> decoder
                 | None -> Decode.fail $"The tag \"{tag}\" was not recognized"
 
             Codec.create
@@ -56,7 +57,9 @@ module VariantCodecBuilder =
                 (match variantEncoding with
                  | TagAndValue(tagName, valueName) ->
                      Decode.field tagName Decode.string
-                     |> Decode.andThen (fun tag -> decodeForTag tag valueName)
+                     |> Decode.andThen (fun tag ->
+                         Decode.field valueName (decodeForTag tag)
+                     )
                  | OnTag ->
                      Decode.keys
                      |> Decode.andThen (fun keys ->
@@ -67,7 +70,7 @@ module VariantCodecBuilder =
                              )
 
                          match Seq.tryExactlyOne recognizedKeys with
-                         | Some tag -> decodeForTag tag tag
+                         | Some tag -> Decode.field tag (decodeForTag tag)
                          | None ->
                              let found =
                                  recognizedKeys
@@ -76,6 +79,11 @@ module VariantCodecBuilder =
 
                              Decode.fail
                                  $"Expected exactly one object key but found: {found}"
+                     )
+                 | Tuple ->
+                     Decode.index 0 Decode.string
+                     |> Decode.andThen (fun tag ->
+                         Decode.index 1 (decodeForTag tag)
                      ))
 
     /// <summary>
@@ -106,7 +114,31 @@ module VariantCodecBuilder =
     /// </code>
     /// </example>
     let variantCodecWithTag tagName valueName =
+        if tagName = valueName then
+            invalidArg
+                (nameof valueName)
+                "value name must be distinct from tag name"
+
         VariantCodecBuilder(VariantEncoding.TagAndValue(tagName, valueName))
+
+    /// <summary>
+    /// Build a codec for a union, writing the tag and the value into a 2 element array.
+    /// </summary>
+    /// <example>
+    /// <code lang="fsharp">
+    /// // [ "square", 4 ]
+    /// let codec : Codec&lt;Shape&gt; =
+    ///     variantCodecTuple "type" "value" {
+    ///         let! square = Codec.case "square" Square Codec.int
+    ///         and! circle = Codec.case "circle" Circle Codec.int
+    ///
+    ///         return function
+    ///             | Square width -> square width
+    ///             | Circle radius -> circle radius
+    ///     }
+    /// </code>
+    /// </example>
+    let variantCodecTuple = VariantCodecBuilder(VariantEncoding.Tuple)
 
     /// <summary>
     /// Build a codec for a union, writing an object with a single property named after the case.
@@ -155,6 +187,11 @@ module VariantCodecBuilder =
                                     tagName, Encode.string tag
                                     valueName, caseCodec.Encoder t
                                 ]
+                        | Tuple ->
+                            Encode.tuple2
+                                Encode.string
+                                caseCodec.Encoder
+                                (tag, t)
                 Decoders =
                     Map.ofSeq
                         [ tag, caseCodec.Decoder |> Decode.map caseConstructor ]

--- a/tests/Thoth.Json.Tests/Codec/VariantCodec.fs
+++ b/tests/Thoth.Json.Tests/Codec/VariantCodec.fs
@@ -150,4 +150,49 @@ let tests (runner: TestRunner<'DecoderJsonValue, 'EncoderJsonValue>) =
 
                 equal actual expected
             }
+
+            test
+                "variantCodecWithTag reports an unrecognised tag, not a missing value" {
+                let expected =
+                    Error(
+                        "Error at: `$`\nThe following `failure` occurred with the decoder: The tag \"triangle\" was not recognized"
+                    )
+
+                // The value is absent, so the tag has to be reported before the decoder reaches for it.
+                let actual =
+                    runner.Decode.fromString
+                        (Decode.codec Shape.codecWithTag)
+                        """{"type":"triangle"}"""
+
+                equal actual expected
+
+                let actual =
+                    runner.Decode.fromString
+                        (Decode.codec Shape.codecWithTag)
+                        """{"type":"triangle","value":1}"""
+
+                equal actual expected
+            }
+
+            test
+                "variantCodecTuple reports an unrecognised tag, not a missing element" {
+                let expected =
+                    Error(
+                        "Error at: `$`\nThe following `failure` occurred with the decoder: The tag \"triangle\" was not recognized"
+                    )
+
+                let actual =
+                    runner.Decode.fromString
+                        (Decode.codec Shape.codecTuple)
+                        """["triangle"]"""
+
+                equal actual expected
+
+                let actual =
+                    runner.Decode.fromString
+                        (Decode.codec Shape.codecTuple)
+                        """["triangle",1]"""
+
+                equal actual expected
+            }
         ]

--- a/tests/Thoth.Json.Tests/Codec/VariantCodec.fs
+++ b/tests/Thoth.Json.Tests/Codec/VariantCodec.fs
@@ -36,8 +36,27 @@ module Shape =
                 | Circle w -> circle w
         }
 
-    let codec': Codec<Shape> =
+    let codecWithTag: Codec<Shape> =
         variantCodecWithTag "type" "value" {
+            let! square = Codec.case "square" Square Codec.int
+
+            and! rectangle =
+                Codec.case
+                    "rectangle"
+                    Rectangle
+                    (Codec.tuple2 Codec.int Codec.int)
+
+            and! circle = Codec.case "circle" Circle Codec.int
+
+            return
+                function
+                | Square w -> square w
+                | Rectangle(w, h) -> rectangle (w, h)
+                | Circle w -> circle w
+        }
+
+    let codecTuple: Codec<Shape> =
+        variantCodecTuple {
             let! square = Codec.case "square" Square Codec.int
 
             and! rectangle =
@@ -59,7 +78,7 @@ let tests (runner: TestRunner<'DecoderJsonValue, 'EncoderJsonValue>) =
     testList
         "VariantCodec"
         [
-            test "variantCodec works for simple case 1" {
+            test "variantCodec works for simple case" {
                 let expected = Square 4
 
                 let actual = roundTrip runner Shape.codec expected
@@ -79,22 +98,42 @@ let tests (runner: TestRunner<'DecoderJsonValue, 'EncoderJsonValue>) =
                 equal actual expected
             }
 
-            test "variantCodec works for simple case 2" {
+            test "variantCodecWithTag works for simple case" {
                 let expected = Square 4
 
-                let actual = roundTrip runner Shape.codec' expected
+                let actual = roundTrip runner Shape.codecWithTag expected
 
                 equal actual expected
 
                 let expected = Rectangle(7, 2)
 
-                let actual = roundTrip runner Shape.codec' expected
+                let actual = roundTrip runner Shape.codecWithTag expected
 
                 equal actual expected
 
                 let expected = Circle 3
 
-                let actual = roundTrip runner Shape.codec' expected
+                let actual = roundTrip runner Shape.codecWithTag expected
+
+                equal actual expected
+            }
+
+            test "variantCodecTuple works for simple case" {
+                let expected = Square 99
+
+                let actual = roundTrip runner Shape.codecTuple expected
+
+                equal actual expected
+
+                let expected = Rectangle(3, 4)
+
+                let actual = roundTrip runner Shape.codecTuple expected
+
+                equal actual expected
+
+                let expected = Circle 8
+
+                let actual = roundTrip runner Shape.codecTuple expected
 
                 equal actual expected
             }

--- a/tests/Thoth.Json.Tests/Codec/VariantCodec.fs
+++ b/tests/Thoth.Json.Tests/Codec/VariantCodec.fs
@@ -137,4 +137,17 @@ let tests (runner: TestRunner<'DecoderJsonValue, 'EncoderJsonValue>) =
 
                 equal actual expected
             }
+
+            test "variantCodecTuple produces correct JSON for a simple case" {
+                let shape = Rectangle(3, 4)
+
+                let actual =
+                    shape
+                    |> Encode.codec Shape.codecTuple
+                    |> runner.Encode.toString 0
+
+                let expected = """["rectangle",[3,4]]"""
+
+                equal actual expected
+            }
         ]


### PR DESCRIPTION
I noticed that the old style of encoding variants as a tuple was missing from the codecs! 

```json
[ "square", 4 ]

[ "rectangle", [ 7, 2 ] ]
```

This PR adds that along with some tests.

I also added the terminology from [this page](https://github.com/Tarmil/FSharp.SystemTextJson/blob/master/docs/Customizing.md?utm_source=chatgpt.com#base-union-encoding) to the docs in order to help people choose an encoding. 